### PR TITLE
Auto-sync schedule slides with the event schedule

### DIFF
--- a/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminScheduleRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminScheduleRouting.kt
@@ -84,7 +84,11 @@ fun Application.configureAdminScheduleRouting(app: AppServices) {
 
         post("/admin/schedule/events") {
             call.processForm<NewEvent>(
-                { app.events.add(it).map { redirectionToSchedules }.bind() },
+                {
+                    app.events.add(it).bind()
+                    app.screen.syncScheduleSlides().bind()
+                    redirectionToSchedules
+                },
                 {
                     renderSchedulesPage(
                         newEventForm = it,
@@ -100,7 +104,11 @@ fun Application.configureAdminScheduleRouting(app: AppServices) {
 
         post("/admin/schedule/events/{id}") {
             call.processForm<Event>(
-                { app.events.update(it).map { redirectionToSchedules }.bind() },
+                {
+                    app.events.update(it).bind()
+                    app.screen.syncScheduleSlides().bind()
+                    redirectionToSchedules
+                },
                 { renderEditSchedulePage(call.parameterUUID("id"), eventForm = it).bind() }
             )
         }
@@ -120,6 +128,7 @@ fun Application.configureAdminScheduleRouting(app: AppServices) {
                 call.userSession(app).bind()
                 val eventId = call.parameterUUID("id").bind()
                 app.events.delete(eventId).bind()
+                app.screen.syncScheduleSlides().bind()
             }
         }
 
@@ -130,6 +139,7 @@ fun Application.configureAdminScheduleRouting(app: AppServices) {
                 call.userSession(app).bind()
                 val events = app.events.getAll().bind()
                 val created = app.events.add(NewEvent.make(events, app.time)).bind()
+                app.screen.syncScheduleSlides().bind()
                 CreatedEvent(created.id.toString())
             }
         }
@@ -172,8 +182,15 @@ fun Application.configureAdminScheduleRouting(app: AppServices) {
             }
         }
 
+        // Toggling visibility changes which dates have a public event, so re-sync the
+        // schedule slides (hiding the last public event on a date removes its slide).
         put("/admin/schedule/events/{id}/setVisible/{state}") {
-            call.switchApiUuid { id, state -> app.events.setVisible(id, state) }
+            call.switchApiUuid { id, state ->
+                either {
+                    app.events.setVisible(id, state).bind()
+                    app.screen.syncScheduleSlides().bind()
+                }
+            }
         }
 
         // Bump a single event by N minutes, preserving its duration.
@@ -183,6 +200,7 @@ fun Application.configureAdminScheduleRouting(app: AppServices) {
                 val id = call.parameterUUID("id").bind()
                 val minutes = call.parameterInt("minutes").bind()
                 app.events.nudge(id, minutes.minutes).bind()
+                app.screen.syncScheduleSlides().bind()
             }
         }
 
@@ -194,6 +212,7 @@ fun Application.configureAdminScheduleRouting(app: AppServices) {
                 val minutes = call.parameterInt("minutes").bind()
                 val event = app.events.get(id).bind()
                 app.events.shiftFrom(event.startTime, minutes.minutes).bind()
+                app.screen.syncScheduleSlides().bind()
             }
         }
 

--- a/src/main/kotlin/party/jml/partyboi/screen/ScreenService.kt
+++ b/src/main/kotlin/party/jml/partyboi/screen/ScreenService.kt
@@ -10,10 +10,12 @@ import party.jml.partyboi.AppServices
 import party.jml.partyboi.Service
 import party.jml.partyboi.data.UUIDSerializer
 import party.jml.partyboi.data.UUIDv7
+import party.jml.partyboi.screen.slides.ScheduleSlide
 import party.jml.partyboi.screen.slides.Slide
 import party.jml.partyboi.screen.slides.TextSlide
 import party.jml.partyboi.signals.Signal
 import party.jml.partyboi.system.AppResult
+import party.jml.partyboi.system.toDate
 import party.jml.partyboi.voting.CompoResult
 import java.util.*
 import kotlin.concurrent.schedule
@@ -59,6 +61,27 @@ class ScreenService(app: AppServices) : Service(app) {
 
     suspend fun addSlide(slideSet: String, slide: Slide<*>) =
         repository.add(slideSet, slide, makeVisible = false, readOnly = false)
+
+    // Keep the slide set's schedule slides in sync with the dates that have a public
+    // event: add a (visible) slide for any such date that lacks one, and remove slides
+    // for dates that no longer have a public event. Idempotent, so it is safe to call
+    // after any event change.
+    suspend fun syncScheduleSlides(slideSet: String = SlideSetRow.DEFAULT): AppResult<Unit> = either {
+        val publicDates = app.events.getPublic().bind()
+            .map { it.startTime.toDate() }
+            .toSet()
+        val scheduleSlides = repository.getSlideSetSlides(slideSet).bind()
+            .mapNotNull { row -> (row.getSlide() as? ScheduleSlide)?.let { it.date to row.id } }
+        val existingDates = scheduleSlides.map { it.first }.toSet()
+
+        scheduleSlides
+            .filter { (date, _) -> date !in publicDates }
+            .forEach { (_, id) -> repository.delete(id).bind() }
+
+        publicDates.minus(existingDates).sorted().forEach { date ->
+            repository.add(slideSet, ScheduleSlide(date), makeVisible = true, readOnly = false).bind()
+        }
+    }
 
     suspend fun update(id: UUID, slide: Slide<*>) = either {
         val updatedRow = repository.update(id, slide).bind()

--- a/src/main/kotlin/party/jml/partyboi/screen/admin/AdminScreenPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/screen/admin/AdminScreenPage.kt
@@ -183,12 +183,6 @@ object AdminScreenPage {
                             +" Full screen image"
                         }
                     }
-                    li {
-                        flatPostButton("/admin/screen/${slideSet}/schedule") {
-                            icon(Icon("calendar"))
-                            +" All missing schedule slides"
-                        }
-                    }
                 }
             }
         }

--- a/src/main/kotlin/party/jml/partyboi/screen/admin/AdminScreenRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/screen/admin/AdminScreenRouting.kt
@@ -15,7 +15,6 @@ import party.jml.partyboi.form.Form
 import party.jml.partyboi.screen.SlideSetRow
 import party.jml.partyboi.screen.slides.*
 import party.jml.partyboi.system.AppResult
-import party.jml.partyboi.system.toDate
 import party.jml.partyboi.templates.Page
 import party.jml.partyboi.templates.Redirection
 import party.jml.partyboi.templates.Renderable
@@ -128,27 +127,6 @@ fun Application.configureAdminScreenRouting(app: AppServices) {
                 call.userSession(app).bind()
                 val slideSetName = call.parameterString("slideSet").bind()
                 app.screen.addSlide(slideSetName, ImageSlide.Empty).bind()
-            }
-        }
-
-        post("/admin/screen/{slideSet}/schedule") {
-            call.apiRespond {
-                call.userSession(app).bind()
-                val slideSetName = call.parameterString("slideSet").bind()
-                val events = app.events.getPublic().bind()
-                val allDates = events.map { it.startTime.toDate() }.distinct().sorted()
-                val existingSlides = app.screen.getSlideSet(slideSetName).bind()
-                val existingDates = existingSlides.flatMap {
-                    val slide = it.getSlide()
-                    when (slide) {
-                        is ScheduleSlide -> listOf(slide.date)
-                        else -> emptyList()
-                    }
-                }.distinct()
-
-                allDates.minus(existingDates).forEach { date ->
-                    app.screen.addSlide(slideSetName, ScheduleSlide(date)).bind()
-                }
             }
         }
 

--- a/src/test/kotlin/party/jml/AdminScheduleTest.kt
+++ b/src/test/kotlin/party/jml/AdminScheduleTest.kt
@@ -5,11 +5,14 @@ import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
 import it.skrape.matchers.toBe
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import party.jml.partyboi.AppServices
 import party.jml.partyboi.schedule.NewEvent
+import party.jml.partyboi.screen.SlideSetRow
+import party.jml.partyboi.screen.slides.ScheduleSlide
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
@@ -266,6 +269,80 @@ class AdminScheduleTest : PartyboiTester {
         }.apply { assertNotEquals(HttpStatusCode.OK, status) }
         assertEquals(at(23, 30), app!!.events.get(id!!).getOrNull()!!.endTime)
     }
+
+    // Adding (or moving) an event to a date that has no schedule slide yet generates a
+    // visible schedule slide for it in the default slide set. Generation is idempotent:
+    // adding more events on a date that already has a slide does not duplicate it.
+    @Test
+    fun testEventChangesGenerateScheduleSlides() = test {
+        var app: AppServices? = null
+        setupServices {
+            app = this
+            either { addTestAdmin(this@setupServices).bind() }
+        }
+
+        it.login("admin")
+
+        // A new date produces a visible schedule slide
+        it.post("/admin/schedule/events", eventForm("First", 1)) { _ -> }
+        assertEquals(setOf(LocalDate(2026, 6, 1)), visibleScheduleSlideDates(app!!))
+
+        // Another event on the same date does not create a duplicate slide
+        it.post("/admin/schedule/events", eventForm("Second", 1)) { _ -> }
+        assertEquals(setOf(LocalDate(2026, 6, 1)), visibleScheduleSlideDates(app!!))
+
+        // A second date adds a second slide
+        it.post("/admin/schedule/events", eventForm("Third", 2)) { _ -> }
+        assertEquals(setOf(LocalDate(2026, 6, 1), LocalDate(2026, 6, 2)), visibleScheduleSlideDates(app!!))
+    }
+
+    // When a date loses its last public event — by deletion or by being hidden — its
+    // now-empty schedule slide is removed. A date that still has other public events
+    // keeps its slide.
+    @Test
+    fun testEmptyScheduleSlidesAreRemoved() = test {
+        var app: AppServices? = null
+        setupServices {
+            app = this
+            either { addTestAdmin(this@setupServices).bind() }
+        }
+
+        it.login("admin")
+
+        // Day 1 has two events, day 2 has one -> a slide for each date
+        it.post("/admin/schedule/events", eventForm("A1", 1)) { _ -> }
+        it.post("/admin/schedule/events", eventForm("A2", 1)) { _ -> }
+        it.post("/admin/schedule/events", eventForm("B", 2)) { _ -> }
+        assertEquals(setOf(LocalDate(2026, 6, 1), LocalDate(2026, 6, 2)), visibleScheduleSlideDates(app!!))
+
+        suspend fun eventId(name: String) = app!!.events.getAll().getOrNull()!!.first { it.name == name }.id
+
+        // Deleting the only event on day 2 removes its slide
+        it.client.delete("/admin/schedule/events/${eventId("B")}")
+            .apply { assertEquals(HttpStatusCode.OK, status) }
+        assertEquals(setOf(LocalDate(2026, 6, 1)), visibleScheduleSlideDates(app!!))
+
+        // Deleting one of two events on day 1 keeps the slide (still a public event there)
+        it.client.delete("/admin/schedule/events/${eventId("A1")}")
+            .apply { assertEquals(HttpStatusCode.OK, status) }
+        assertEquals(setOf(LocalDate(2026, 6, 1)), visibleScheduleSlideDates(app!!))
+
+        // Hiding the last remaining event on day 1 removes its slide too
+        it.buttonClick("/admin/schedule/events/${eventId("A2")}/setVisible/false")
+        assertEquals(emptySet(), visibleScheduleSlideDates(app!!))
+    }
+
+    private fun eventForm(name: String, day: Int) = formData {
+        append("name", name)
+        append("startTime", "2026-06-0${day}T12:00:00")
+        append("endTime", "")
+        append("visible", "true")
+    }
+
+    private suspend fun visibleScheduleSlideDates(app: AppServices): Set<LocalDate> =
+        app.screen.getSlideSet(SlideSetRow.DEFAULT).getOrNull()!!
+            .mapNotNull { row -> (row.getSlide() as? ScheduleSlide)?.takeIf { row.visible }?.date }
+            .toSet()
 
     private suspend fun TestHtmlClient.putJson(url: String, body: String) {
         client.put(url) {


### PR DESCRIPTION
## What

Replaces the manual **"All missing schedule slides"** dropdown option (at `/admin/screen/*`) with automatic, two-way syncing of schedule slides against the event schedule.

- When an event is **added or moved** onto a date that has no schedule slide, a **visible** slide is created in the **default** slide set.
- When a date **loses its last public event** — by deletion or by being hidden — its now-empty schedule slide is **removed**.

## How

`ScreenService.syncScheduleSlides()` keeps the default slide set's schedule slides in step with the dates that have a public event: it adds a visible slide for any such date that lacks one, and removes slides for dates that no longer have a public event. It's idempotent, so it's safe to call after every event mutation.

It's wired into every event change that can alter the set of public dates:
- Add (form + keyboard-scaffold), full edit, ±15min nudge, "running late" cascade shift
- **Delete** event
- **Toggle visibility**

Inline start/end time edits are time-only and can't change a date, so they have no hook.

The old `POST /admin/screen/{slideSet}/schedule` route and its dropdown entry are removed.

## Behavior note

Slide existence is driven by **public** (visible) events — this preserves the original generation logic. As a result, hiding the last visible event on a date removes its on-screen slide, and re-showing recreates a fresh one. Easy to dial back to deletion/move-only if that's not wanted.

## Tests

- `testEventChangesGenerateScheduleSlides` — adding events generates visible slides; no duplicates per date.
- `testEmptyScheduleSlidesAreRemoved` — deleting/hiding the last event on a date removes its slide; a date with other public events keeps it.

Full suite (`./gradlew test`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)