### PR TITLE
Convert uploaded tracker modules to normalized audio

### DIFF
--- a/src/main/kotlin/party/jml/partyboi/AppServices.kt
+++ b/src/main/kotlin/party/jml/partyboi/AppServices.kt
@@ -23,6 +23,7 @@ import party.jml.partyboi.entries.FileRepository
 import party.jml.partyboi.entries.PreviewRepository
 import party.jml.partyboi.ffmpeg.DockerFileShare
 import party.jml.partyboi.ffmpeg.FfmpegService
+import party.jml.partyboi.ffmpeg.TrackerToolsService
 import party.jml.partyboi.infoscreen.InfoScreenService
 import party.jml.partyboi.messages.MessageRepository
 import party.jml.partyboi.schedule.EventRepository
@@ -66,6 +67,7 @@ interface AppServices {
     val workQueue: WorkQueueService
     val dockerFileShare: DockerFileShare
     val ffmpeg: FfmpegService
+    val trackerTools: TrackerToolsService
     val eventSignalEmitter: EventSignalEmitter
     val sync: SyncService
     val recaptcha: RecaptchaService
@@ -101,6 +103,7 @@ class AppServicesImpl(
     override val workQueue = WorkQueueService(this)
     override val dockerFileShare = DockerFileShare(this)
     override val ffmpeg = FfmpegService(this)
+    override val trackerTools = TrackerToolsService(this)
     override val eventSignalEmitter = EventSignalEmitter(this)
     override val sync = SyncService(this)
     override val recaptcha = RecaptchaService(this)

--- a/src/main/kotlin/party/jml/partyboi/entries/FileRepository.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/FileRepository.kt
@@ -32,6 +32,7 @@ import party.jml.partyboi.db.one
 import party.jml.partyboi.db.queryOf
 import party.jml.partyboi.form.FileUpload
 import party.jml.partyboi.system.AppResult
+import party.jml.partyboi.workqueue.ConvertTrackerModule
 import party.jml.partyboi.workqueue.ExtractDuration
 import party.jml.partyboi.workqueue.GeneratePreviewForAudio
 import party.jml.partyboi.workqueue.GeneratePreviewForVideo
@@ -252,12 +253,16 @@ class FileRepository(app: AppServices) : Service(app) {
     suspend fun postProcessUpload(file: FileDesc) {
         if (file.processed) return
         val streamingAudio = FileFormatCategory.streamingAudio.formats().flatMap { it.extensions }
+        val tracker = FileFormatCategory.tracker.formats().flatMap { it.extensions }
         val video = FileFormatCategory.video.formats().flatMap { it.extensions }
         when (file.extension) {
             in streamingAudio -> {
                 app.workQueue.addTask(NormalizeLoudness(file))
                 app.workQueue.addTask(GeneratePreviewForAudio(file))
                 app.workQueue.addTask(ExtractDuration(file))
+            }
+            in tracker -> {
+                app.workQueue.addTask(ConvertTrackerModule(file))
             }
             in video -> {
                 app.workQueue.addTask(GeneratePreviewForVideo(file))

--- a/src/main/kotlin/party/jml/partyboi/ffmpeg/Docker.kt
+++ b/src/main/kotlin/party/jml/partyboi/ffmpeg/Docker.kt
@@ -1,12 +1,20 @@
 package party.jml.partyboi.ffmpeg
 
 import com.github.dockerjava.api.DockerClient
+import com.github.dockerjava.api.async.ResultCallback
 import com.github.dockerjava.api.command.InspectContainerResponse
 import com.github.dockerjava.api.exception.NotFoundException
+import com.github.dockerjava.api.model.Bind
+import com.github.dockerjava.api.model.Frame
+import com.github.dockerjava.api.model.HostConfig
+import com.github.dockerjava.api.model.PullResponseItem
+import com.github.dockerjava.api.model.Volume
 import com.github.dockerjava.core.DefaultDockerClientConfig
 import com.github.dockerjava.core.DockerClientImpl
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 import com.github.dockerjava.transport.DockerHttpClient
+import io.ktor.util.logging.*
+import java.io.File
 import java.net.InetAddress
 import java.time.Duration
 
@@ -33,5 +41,83 @@ object Docker {
         client.inspectContainerCmd(containerId).exec()
     } catch (_: NotFoundException) {
         null
+    }
+
+    fun ensureImageExists(image: String, log: Logger, platform: String? = null) {
+        val client = getClient()
+
+        val imageExists = client.listImagesCmd()
+            .withReferenceFilter(image)
+            .exec()
+            .any { it.repoTags?.contains(image) == true }
+
+        if (!imageExists) {
+            log.info("$image does not exist, pulling it...")
+            // Split the repository from the tag: docker-java's pullImageCmd expects the bare
+            // repository, with the tag supplied separately. A bare repository (no ':') pulls latest.
+            val tagSeparator = image.lastIndexOf(':')
+            val repository = if (tagSeparator >= 0) image.substring(0, tagSeparator) else image
+            val tag = if (tagSeparator >= 0) image.substring(tagSeparator + 1) else "latest"
+            client.pullImageCmd(repository)
+                .withTag(tag)
+                // Single-arch images (e.g. amd64-only) have no manifest for the host arch on Apple
+                // Silicon; pinning the platform lets Docker pull and run it under emulation.
+                .apply { if (platform != null) withPlatform(platform) }
+                .exec(object : ResultCallback.Adapter<PullResponseItem>() {})
+                .awaitCompletion()
+        }
+    }
+
+    fun runContainer(
+        image: String,
+        sharedDir: File,
+        mountPoint: String,
+        entrypoint: String?,
+        args: List<String>,
+        label: String,
+        log: Logger,
+        platform: String? = null,
+    ): String {
+        val client = getClient()
+
+        val binds = listOfNotNull(
+            Bind(sharedDir.toString(), Volume(mountPoint))
+        )
+
+        val hostConfig = HostConfig
+            .newHostConfig()
+            .withBinds(binds)
+
+        val container = client.createContainerCmd(image)
+            .withHostConfig(hostConfig)
+            .apply { if (entrypoint != null) withEntrypoint(entrypoint) }
+            .apply { if (platform != null) withPlatform(platform) }
+            .withCmd(args)
+            .withTty(false)
+            .withAttachStdout(true)
+            .withAttachStderr(true)
+            .exec()
+
+        client.startContainerCmd(container.id).exec()
+        client.waitContainerCmd(container.id).start().awaitCompletion()
+
+        log.info("Run $label with arguments: $args and bindings: $binds")
+
+        val logs = StringBuilder()
+        client.logContainerCmd(container.id)
+            .withStdOut(true)
+            .withStdErr(true)
+            .withTimestamps(false)
+            .exec(object : ResultCallback.Adapter<Frame>() {
+                override fun onNext(frame: Frame) {
+                    logs.append(String(frame.payload))
+                }
+            }).awaitCompletion()
+
+        log.info(logs.toString())
+
+        client.removeContainerCmd(container.id).exec()
+
+        return logs.toString()
     }
 }

--- a/src/main/kotlin/party/jml/partyboi/ffmpeg/FfmpegService.kt
+++ b/src/main/kotlin/party/jml/partyboi/ffmpeg/FfmpegService.kt
@@ -1,7 +1,5 @@
 package party.jml.partyboi.ffmpeg
 
-import com.github.dockerjava.api.async.ResultCallback
-import com.github.dockerjava.api.model.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import party.jml.partyboi.AppServices
@@ -9,23 +7,7 @@ import java.io.File
 
 
 class FfmpegService(app: AppServices) : party.jml.partyboi.Service(app) {
-    fun ensureFfmpegExists() {
-        val client = Docker.getClient()
-
-        val imageExists = client.listImagesCmd()
-            .withReferenceFilter(IMAGE)
-            .exec()
-            .any { it.repoTags?.contains(IMAGE) == true }
-
-        if (!imageExists) {
-            log.info("$IMAGE does not exist, pulling it...")
-            client.pullImageCmd(IMAGE)
-                .withTag("latest")
-                .exec(object :
-                    ResultCallback.Adapter<PullResponseItem>() {})
-                .awaitCompletion()
-        }
-    }
+    fun ensureFfmpegExists() = Docker.ensureImageExists(IMAGE, log)
 
     fun normalizeLoudness(input: File): File {
         ensureFfmpegExists()
@@ -250,48 +232,16 @@ class FfmpegService(app: AppServices) : party.jml.partyboi.Service(app) {
     private fun runFfprobe(vararg args: String): String =
         runContainer(entrypoint = "ffprobe", args = args.toList(), label = "ffprobe")
 
-    private fun runContainer(entrypoint: String?, args: List<String>, label: String): String {
-        val client = Docker.getClient()
-
-        val binds = listOfNotNull(
-            Bind(app.dockerFileShare.sharedDir.toString(), Volume("/files"))
+    private fun runContainer(entrypoint: String?, args: List<String>, label: String): String =
+        Docker.runContainer(
+            image = IMAGE,
+            sharedDir = app.dockerFileShare.sharedDir,
+            mountPoint = "/files",
+            entrypoint = entrypoint,
+            args = args,
+            label = label,
+            log = log,
         )
-
-        val hostConfig = HostConfig
-            .newHostConfig()
-            .withBinds(binds)
-
-        val container = client.createContainerCmd(IMAGE)
-            .withHostConfig(hostConfig)
-            .apply { if (entrypoint != null) withEntrypoint(entrypoint) }
-            .withCmd(args)
-            .withTty(false)
-            .withAttachStdout(true)
-            .withAttachStderr(true)
-            .exec()
-
-        client.startContainerCmd(container.id).exec()
-        client.waitContainerCmd(container.id).start().awaitCompletion()
-
-        log.info("Run $label with arguments: $args and bindings: $binds")
-
-        val logs = StringBuilder()
-        client.logContainerCmd(container.id)
-            .withStdOut(true)
-            .withStdErr(true)
-            .withTimestamps(false)
-            .exec(object : ResultCallback.Adapter<Frame>() {
-                override fun onNext(frame: Frame) {
-                    logs.append(String(frame.payload))
-                }
-            }).awaitCompletion()
-
-        log.info(logs.toString())
-
-        client.removeContainerCmd(container.id).exec()
-
-        return logs.toString()
-    }
 
     inline fun <reified T> String.extractJson(): T {
         val regex = Regex("""(?s)\{.*?}""")

--- a/src/main/kotlin/party/jml/partyboi/ffmpeg/TrackerToolsService.kt
+++ b/src/main/kotlin/party/jml/partyboi/ffmpeg/TrackerToolsService.kt
@@ -1,0 +1,39 @@
+package party.jml.partyboi.ffmpeg
+
+import party.jml.partyboi.AppServices
+import party.jml.partyboi.Service
+import java.io.File
+
+/**
+ * Renders tracker modules (.mod, .s3m, .xm, .it, .mptm, ...) to WAV using the
+ * `ilkkahanninen/partyboi-trackertools` Docker image. The image mounts the shared directory at
+ * /work and takes positional `input output` arguments.
+ */
+class TrackerToolsService(app: AppServices) : Service(app) {
+    fun convertToWav(input: File): File {
+        Docker.ensureImageExists(IMAGE, log, platform = PLATFORM)
+
+        return app.dockerFileShare.use(input) { sharedInput ->
+            val output = app.dockerFileShare.createTempFile("trackerWav", ".wav")
+            Docker.runContainer(
+                image = IMAGE,
+                sharedDir = app.dockerFileShare.sharedDir,
+                mountPoint = "/work",
+                entrypoint = null,
+                args = listOf("/work/${sharedInput.localFile.name}", "/work/${output.localFile.name}"),
+                label = "trackertools",
+                log = log,
+                platform = PLATFORM,
+            )
+            output.localFile
+        }
+    }
+
+    companion object {
+        const val IMAGE = "ilkkahanninen/partyboi-trackertools:latest"
+
+        // The image is published for linux/amd64 only; pin it so Apple Silicon hosts run it under
+        // emulation instead of failing to find a matching manifest.
+        const val PLATFORM = "linux/amd64"
+    }
+}

--- a/src/main/kotlin/party/jml/partyboi/workqueue/Task.kt
+++ b/src/main/kotlin/party/jml/partyboi/workqueue/Task.kt
@@ -41,6 +41,35 @@ data class NormalizeLoudness(
 }
 
 @Serializable
+data class ConvertTrackerModule(
+    val file: FileDesc
+) : Task {
+    override suspend fun execute(app: AppServices): AppResult<Unit> = either {
+        val fileDesc = app.files.getById(file.id).bind()
+        val inputFile = app.files.getStorageFile(fileDesc.id)
+
+        val wav = app.trackerTools.convertToWav(inputFile)
+        val normalizedFile = app.ffmpeg.normalizeLoudness(wav)
+
+        val normalizedFileDesc = app.files.store(
+            tempFile = normalizedFile,
+            originalFilename = Path(fileDesc.originalFilename).nameWithoutExtension + " (normalized).flac",
+            processed = true,
+            info = "Converted from tracker module and loudness normalized to -14 LUFS",
+        ).bind()
+
+        app.entries.getByFileId(fileDesc.id).onRight { entry ->
+            app.entries.associateFile(
+                fileId = normalizedFileDesc.id,
+                entryId = entry.id
+            )
+            app.workQueue.addTask(GeneratePreviewForAudio(normalizedFileDesc))
+            app.workQueue.addTask(ExtractDuration(normalizedFileDesc))
+        }
+    }
+}
+
+@Serializable
 data class GeneratePreviewForVideo(
     val file: FileDesc
 ) : Task {

--- a/src/main/kotlin/party/jml/partyboi/workqueue/WorkQueueService.kt
+++ b/src/main/kotlin/party/jml/partyboi/workqueue/WorkQueueService.kt
@@ -1,9 +1,11 @@
 package party.jml.partyboi.workqueue
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import party.jml.partyboi.AppServices
+import party.jml.partyboi.Logging
 
-class WorkQueueService(val app: AppServices) {
+class WorkQueueService(val app: AppServices) : Logging() {
     val repository = WorkQueueRepository(app)
 
     suspend fun addTask(task: Task) = repository.add(task)
@@ -11,13 +13,30 @@ class WorkQueueService(val app: AppServices) {
     suspend fun start() {
         repository.cancel()
         while (true) {
-            repository.takeNext().fold({
-                repository.cancel()
+            try {
+                repository.takeNext().fold({
+                    repository.cancel()
+                    delay(1000)
+                }, { taskRow ->
+                    val success = try {
+                        taskRow.task.execute(app).isRight()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (error: Throwable) {
+                        // A task that throws (e.g. a Docker image that cannot be pulled) must not
+                        // crash the worker loop — log it and mark the task as failed.
+                        log.error("Task ${taskRow.id} threw an exception", error)
+                        false
+                    }
+                    repository.setState(taskRow.id, if (success) TaskState.Success else TaskState.Failed)
+                })
+            } catch (e: CancellationException) {
+                throw e
+            } catch (error: Throwable) {
+                // Never let a failure in the queue plumbing (e.g. a DB hiccup) kill the worker loop.
+                log.error("Work queue iteration failed", error)
                 delay(1000)
-            }, { taskRow ->
-                val success = taskRow.task.execute(app).isRight()
-                repository.setState(taskRow.id, if (success) TaskState.Success else TaskState.Failed)
-            })
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Tracker modules (`.mod`, `.s3m`, `.xm`, `.it`, `.mptm`) previously received no audio processing because FFmpeg cannot decode them. This change renders them to audio so they behave like any other audio upload:

1. Convert the module to WAV using the `ilkkahanninen/partyboi-trackertools` Docker image.
2. Reuse the existing FFmpeg loudness normalization (-14 LUFS).
3. Store the normalized `.flac` on the entry.
4. Generate a waveform preview and extract duration (reusing the existing `GeneratePreviewForAudio` / `ExtractDuration` tasks).

End result: uploading a `.mod`/`.xm`/`.s3m`/`.it`/`.mptm` produces the same artifacts as uploading an `.mp3`.

## Changes

- **`ffmpeg/Docker.kt`** — Extracted a generic container runner (`ensureImageExists` / `runContainer`) from `FfmpegService`, with an optional `platform` override. The trackertools image is `linux/amd64`-only, so the platform must be pinned to run under emulation on Apple Silicon.
- **`ffmpeg/TrackerToolsService.kt`** (new) — `convertToWav(input)` runs the trackertools image (shared dir mounted at `/work`, positional `input output` args), pinned to `linux/amd64`.
- **`ffmpeg/FfmpegService.kt`** — Refactored to delegate to the shared `Docker` helpers (behavior unchanged).
- **`AppServices.kt`** — Registered `trackerTools`.
- **`workqueue/Task.kt`** — Added `ConvertTrackerModule`, which converts, normalizes, stores+associates the result, and enqueues the preview/duration tasks on the converted file.
- **`entries/FileRepository.kt`** — `postProcessUpload` enqueues `ConvertTrackerModule` for the `tracker` format category.
- **`workqueue/WorkQueueService.kt`** — Hardened the worker loop: a thrown task exception (or queue-plumbing failure) is now logged and the task marked `Failed` instead of crashing the loop; `CancellationException` is still propagated.

## Notes

- The trackertools image's exotic *prefix-detected* formats (e.g. TFMX) won't be recognized because the shared file is renamed to `temp-<uuid>.ext`; the supported tracker categories (mod/s3m/xm/it/mptm) are all suffix-detected and work.

## Verification

- `./gradlew test` passes (H2 suite; the new task path requires Docker and is only enqueued for tracker uploads).
- Manual end-to-end (needs Docker): upload a `.mod`/`.xm` to the dev server and confirm the trackertools run, loudnorm passes, and the resulting normalized file + waveform preview + duration on the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)