### PR TITLE
Add first-run setup wizard

### DIFF
--- a/src/main/kotlin/party/jml/partyboi/auth/Authentication.kt
+++ b/src/main/kotlin/party/jml/partyboi/auth/Authentication.kt
@@ -11,6 +11,7 @@ import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.util.*
 import party.jml.partyboi.AppServices
+import party.jml.partyboi.AppServicesImpl
 import party.jml.partyboi.data.RedirectInterruption
 import party.jml.partyboi.system.AppResult
 import party.jml.partyboi.system.isTrue
@@ -110,7 +111,19 @@ fun Application.votingRouting(block: Route.() -> Unit) {
 
 fun Application.adminRouting(block: Route.() -> Unit) {
     routing {
-        authenticate("admin") { block() }
+        authenticate("admin") {
+            intercept(ApplicationCallPipeline.Plugins) {
+                val app = AppServicesImpl.globalInstance ?: return@intercept
+                val path = call.request.path()
+                if (path.startsWith("/wizard")) return@intercept
+                val completed = app.settings.wizardCompleted.getOrNull() ?: false
+                if (!completed) {
+                    call.respondRedirect("/wizard")
+                    finish()
+                }
+            }
+            block()
+        }
     }
 }
 

--- a/src/main/kotlin/party/jml/partyboi/frontpage/FrontPageRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/frontpage/FrontPageRouting.kt
@@ -1,6 +1,7 @@
 package party.jml.partyboi.frontpage
 
 import io.ktor.server.application.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import party.jml.partyboi.AppServices
 import party.jml.partyboi.auth.optionalUserSession
@@ -11,7 +12,11 @@ import party.jml.partyboi.templates.respondEither
 fun Application.configureFrontPageRouting(app: AppServices) {
     publicRouting {
         get("/") {
-            call.optionalUserSession(app) // FIXME: this is a hack to ensure that new session gets loaded before rendering
+            val user = call.optionalUserSession(app)
+            if (user?.isAdmin == true && app.settings.wizardCompleted.getOrNull() != true) {
+                call.respondRedirect("/wizard")
+                return@get
+            }
             call.respondEither {
                 val events = app.events.getAll().bind().filter { it.visible }
                 val infoScreen = app.screen

--- a/src/main/kotlin/party/jml/partyboi/plugins/Routing.kt
+++ b/src/main/kotlin/party/jml/partyboi/plugins/Routing.kt
@@ -30,6 +30,7 @@ import party.jml.partyboi.templates.respondPage
 import party.jml.partyboi.users.configureUserMgmtRouting
 import party.jml.partyboi.voting.admin.configureAdminVotingRouting
 import party.jml.partyboi.voting.configureVotingRouting
+import party.jml.partyboi.wizard.configureWizardRouting
 import party.jml.partyboi.workqueue.admin.configureAdminTasksRouting
 
 @Serializable
@@ -83,4 +84,5 @@ fun Application.configureDefaultRouting(app: AppServices) {
     configureAdminErrorLogRouting(app)
     configureAdminTasksRouting(app)
     configureSyncRouting(app)
+    configureWizardRouting(app)
 }

--- a/src/main/kotlin/party/jml/partyboi/settings/SettingsService.kt
+++ b/src/main/kotlin/party/jml/partyboi/settings/SettingsService.kt
@@ -18,6 +18,7 @@ class SettingsService(app: AppServices) : Service(app) {
     val verifiedEmailsOnly = property("verifiedEmailsOnly", true)
     val resultsFileHeader = property("resultsFileHeader", "")
     val colorScheme = property("colorScheme", ColorScheme.Blue)
+    val wizardCompleted = property("wizardCompleted", false)
 
     suspend fun getGeneralSettings() = either {
         GeneralSettings(

--- a/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
@@ -1,0 +1,59 @@
+package party.jml.partyboi.wizard
+
+import kotlinx.datetime.TimeZone
+import kotlinx.html.*
+import party.jml.partyboi.form.DropdownOption
+import party.jml.partyboi.form.Form
+import party.jml.partyboi.form.renderForm
+import party.jml.partyboi.settings.GeneralSettings
+import party.jml.partyboi.templates.ColorScheme
+import party.jml.partyboi.templates.Page
+
+object WizardPage {
+    fun renderSettingsStep(settings: Form<GeneralSettings>, autofillTimeZone: Boolean) = Page("Setup wizard") {
+        h1 { +"Welcome to Partyboi" }
+
+        article {
+            header { +"Setup wizard — step 1 of 2" }
+            p {
+                +"Let's get the basics set up. First, pick the time zone the party runs in and the "
+                +"colour scheme you'd like to use. You can change all of these later under "
+                em { +"Admin → Settings" }
+                +"."
+            }
+        }
+
+        renderForm(
+            title = "General settings",
+            url = "/wizard",
+            form = settings,
+            submitButtonLabel = "Save and continue",
+            options = mapOf(
+                "colorScheme" to DropdownOption.fromEnum<ColorScheme> { it.displayName },
+                "timeZone" to TimeZone.availableZoneIds
+                    .toList()
+                    .sorted()
+                    .map(DropdownOption.fromString),
+            ),
+        )
+
+        if (autofillTimeZone) {
+            script {
+                unsafe {
+                    +"""
+                    (function() {
+                        try {
+                            var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                            if (!tz) return;
+                            var sel = document.querySelector('select[name="timeZone"]');
+                            if (!sel) return;
+                            var hasOption = Array.prototype.some.call(sel.options, function(o) { return o.value === tz; });
+                            if (hasOption) sel.value = tz;
+                        } catch (e) {}
+                    })();
+                    """.trimIndent()
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/party/jml/partyboi/wizard/WizardRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/wizard/WizardRouting.kt
@@ -1,0 +1,44 @@
+package party.jml.partyboi.wizard
+
+import arrow.core.raise.either
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import party.jml.partyboi.AppServices
+import party.jml.partyboi.auth.adminRouting
+import party.jml.partyboi.data.processForm
+import party.jml.partyboi.form.Form
+import party.jml.partyboi.settings.GeneralSettings
+import party.jml.partyboi.system.AppResult
+import party.jml.partyboi.templates.Page
+import party.jml.partyboi.templates.Redirection
+import party.jml.partyboi.templates.respondEither
+
+fun Application.configureWizardRouting(app: AppServices) {
+    suspend fun renderStep1(form: Form<GeneralSettings>? = null): AppResult<Page> = either {
+        WizardPage.renderSettingsStep(
+            settings = form ?: Form(
+                GeneralSettings::class,
+                app.settings.getGeneralSettings().bind(),
+                initial = false
+            ),
+            autofillTimeZone = form == null,
+        )
+    }
+
+    adminRouting {
+        get("/wizard") {
+            call.respondEither { renderStep1().bind() }
+        }
+
+        post("/wizard") {
+            call.processForm<GeneralSettings>(
+                {
+                    app.settings.saveSettings(it).bind()
+                    app.settings.wizardCompleted.set(true).bind()
+                    Redirection("/admin/voting")
+                },
+                { renderStep1(it).bind() }
+            )
+        }
+    }
+}

--- a/src/syncHarness/kotlin/party/jml/partyboi/syncharness/InstanceClient.kt
+++ b/src/syncHarness/kotlin/party/jml/partyboi/syncharness/InstanceClient.kt
@@ -62,6 +62,22 @@ class InstanceClient(
         postMultipart("/login", listOf("name" to name, "password" to password)).expectOk()
     }
 
+    /**
+     * Complete the first-run setup wizard. A fresh instance redirects every admin request to
+     * /wizard until the wizard has been submitted, so the harness must run it once right after
+     * logging in as admin. Sends the GeneralSettings step with harmless defaults.
+     */
+    suspend fun completeWizard() {
+        postMultipart(
+            "/wizard",
+            listOf(
+                "resultsFileHeader" to "",
+                "colorScheme" to "Blue",
+                "timeZone" to "UTC",
+            ),
+        ).expectOk()
+    }
+
     suspend fun register(name: String, password: String, email: String = "") {
         val resp = postMultipart(
             "/register",

--- a/src/syncHarness/kotlin/party/jml/partyboi/syncharness/Seeder.kt
+++ b/src/syncHarness/kotlin/party/jml/partyboi/syncharness/Seeder.kt
@@ -37,6 +37,9 @@ class Seeder(
         println("[seed/preParty] Logging in as $adminName on master")
         master.login(adminName, adminPassword)
 
+        println("[seed/preParty] Completing setup wizard on master")
+        master.completeWizard()
+
         println("[seed/preParty] Generating master sync token")
         val syncToken = master.generateSyncToken()
 

--- a/src/syncHarness/kotlin/party/jml/partyboi/syncharness/Verifier.kt
+++ b/src/syncHarness/kotlin/party/jml/partyboi/syncharness/Verifier.kt
@@ -34,6 +34,8 @@ class Verifier(
     suspend fun configureRemote() {
         println("[verify] Logging into remote as $adminName")
         remote.login(adminName, adminPassword)
+        println("[verify] Completing setup wizard on remote (admin routes redirect to /wizard until done)")
+        remote.completeWizard()
         println("[verify] Configuring remote to point at $masterInternalUrl with the master's token")
         remote.postMultipart(
             "/sync/remote",

--- a/src/test/kotlin/party/jml/PartyboiTester.kt
+++ b/src/test/kotlin/party/jml/PartyboiTester.kt
@@ -161,6 +161,7 @@ fun <T> ApplicationTestBuilder.setupServices(setupForTest: suspend AppServices.(
             val app = services()
             either {
                 app.settings.automaticVoteKeys.set(AutomaticVoteKeys.DISABLED)
+                app.settings.wizardCompleted.set(true).bind()
                 app.files.deleteAll().bind()
                 app.assets.deleteAll().bind()
                 app.triggers.deleteAll().bind()

--- a/src/test/kotlin/party/jml/WizardTest.kt
+++ b/src/test/kotlin/party/jml/WizardTest.kt
@@ -1,0 +1,78 @@
+package party.jml
+
+import arrow.core.raise.either
+import io.ktor.client.request.forms.*
+import io.ktor.http.*
+import it.skrape.matchers.toBe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WizardTest : PartyboiTester {
+    @Test
+    fun testWizardShownForAdminWhenIncomplete() = test {
+        setupServices {
+            either {
+                addTestAdmin(this@setupServices).bind()
+                settings.wizardCompleted.set(false).bind()
+            }
+        }
+        it.login("admin")
+
+        // Admin navigating to any admin page is redirected to the wizard.
+        it.get("/admin/settings", HttpStatusCode.OK) {
+            relaxed = true
+            findFirst("h1") { text.toBe("Welcome to Partyboi") }
+        }
+
+        // Front page also redirects an incomplete-wizard admin.
+        it.get("/", HttpStatusCode.OK) {
+            relaxed = true
+            findFirst("h1") { text.toBe("Welcome to Partyboi") }
+        }
+    }
+
+    @Test
+    fun testWizardNotShownForNonAdmin() = test {
+        setupServices {
+            either {
+                addTestUser(this@setupServices).bind()
+                settings.wizardCompleted.set(false).bind()
+            }
+        }
+        it.login()
+
+        // Non-admin users on the front page do not get the wizard.
+        it.get("/", HttpStatusCode.OK) {
+            relaxed = true
+            findFirst("h1") {
+                // Front page heading is the configured instance name, definitely not the wizard.
+                assertEquals(false, text.contains("Welcome to Partyboi"))
+            }
+        }
+    }
+
+    @Test
+    fun testWizardSaveRedirectsToVoteKeys() = test {
+        setupServices {
+            either {
+                addTestAdmin(this@setupServices).bind()
+                settings.wizardCompleted.set(false).bind()
+            }
+        }
+        it.login("admin")
+
+        it.post("/wizard", formData {
+            append("resultsFileHeader", "")
+            append("colorScheme", "Blue")
+            append("timeZone", "Europe/Helsinki")
+        }) {
+            it.redirectsTo("/admin/voting")
+        }
+
+        // After completing the wizard, normal admin pages are reachable again.
+        it.get("/admin/settings", HttpStatusCode.OK) {
+            relaxed = true
+            findFirst("h1") { text.toBe("Settings") }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a first-run setup wizard. Until it has been completed, admins are redirected to `/wizard`:

- The admin route pipeline intercepts requests (except `/wizard` itself) and redirects to `/wizard` when `settings.wizardCompleted` is false.
- The front page redirects an admin to `/wizard` under the same condition.

## Changes

- **`wizard/WizardPage.kt`, `wizard/WizardRouting.kt`** (new) — the wizard page and its routes; registered via `configureWizardRouting` in `plugins/Routing.kt`.
- **`settings/SettingsService.kt`** — new `wizardCompleted` setting (default `false`).
- **`auth/Authentication.kt`** — admin routing intercepts and redirects to `/wizard` until completed.
- **`frontpage/FrontPageRouting.kt`** — front page redirects admins to `/wizard` until completed.
- **`PartyboiTester.kt`** — test harness marks the wizard completed during setup so existing tests are unaffected.
- **`WizardTest.kt`** (new) — test coverage for the wizard flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)