### PR TITLE
Bug hunt: 11 correctness & security fixes

### DIFF
--- a/src/main/kotlin/party/jml/partyboi/Application.kt
+++ b/src/main/kotlin/party/jml/partyboi/Application.kt
@@ -22,7 +22,9 @@ fun Application.module() {
 
     launch { app.triggers.start() }
     launch { app.votes.start() }
-    launch { app.workQueue.start() }
+    if (app.config.runWorkQueue) {
+        launch { app.workQueue.start() }
+    }
 
     configureSerialization()
     configureHTTP()

--- a/src/main/kotlin/party/jml/partyboi/Config.kt
+++ b/src/main/kotlin/party/jml/partyboi/Config.kt
@@ -70,6 +70,10 @@ class ConfigReader(private val config: ApplicationConfig) {
 
     // File uploads
     val maxFileUploadSize: Long by lazy { config.propertyOrNull("files.maxSize")?.getSize() ?: -1L }
+
+    // The background work-queue worker. Enabled by default; disabled in tests so its polling loop
+    // doesn't consume/process tasks that the tests set up and assert on.
+    val runWorkQueue: Boolean by lazy { config.propertyOrNull("workQueue.enabled")?.getString() != "false" }
 }
 
 data class RecaptchaConfig(

--- a/src/main/kotlin/party/jml/partyboi/assets/admin/AdminAssetsRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/assets/admin/AdminAssetsRouting.kt
@@ -10,6 +10,7 @@ import party.jml.partyboi.auth.userSession
 import party.jml.partyboi.data.apiRespond
 import party.jml.partyboi.data.parameterPathString
 import party.jml.partyboi.form.collect
+import party.jml.partyboi.form.multipartSizeLimit
 import party.jml.partyboi.templates.Redirection
 import party.jml.partyboi.templates.respondPage
 
@@ -22,7 +23,12 @@ fun Application.configureAdminAssetsRouting(app: AppServices) {
         }
 
         post("/admin/assets") {
-            val (_, files) = call.receiveMultipart(app.config.maxFileUploadSize).collect()
+            val (_, files) = try {
+                call.receiveMultipart(formFieldLimit = multipartSizeLimit(app.config.maxFileUploadSize)).collect()
+            } catch (e: Exception) {
+                call.respondPage(AdminAssetsPage.render(assets = app.assets.getList(), error = e.message ?: "Upload failed"))
+                return@post
+            }
             val uploadedFiles = (files["files"] ?: emptyList()).filter { it.isDefined }
 
             if (uploadedFiles.isEmpty()) {

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/AdminComposRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/AdminComposRouting.kt
@@ -423,9 +423,13 @@ fun Application.configureAdminComposRouting(app: AppServices) {
 }
 
 suspend fun ApplicationCall.hostFile(hostedEntry: ExtractedEntry, filename: Path? = null) {
-    val target = let {
-        val path = hostedEntry.dir.toPath()
-        if (filename == null) path else path.resolve(filename)
+    val baseDir = hostedEntry.dir.toPath().normalize()
+    val target = if (filename == null) baseDir else baseDir.resolve(filename).normalize()
+    // Reject paths that escape the extracted-entry directory (e.g. ../../etc/passwd or an absolute
+    // path) before touching the filesystem.
+    if (!target.startsWith(baseDir)) {
+        respondPage(NotFound("File not found"))
+        return
     }
     if (target.toFile().isDirectory()) {
         val entries = target.listDirectoryEntries()

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/ResultsRunService.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/ResultsRunService.kt
@@ -21,6 +21,9 @@ class ResultsRunService(app: AppServices) : Service(app) {
         val currentState = resultsSteps.get().bind()
 
         if (currentState == null || currentState.hasEnded() || currentState.compoId != compo.id) {
+            // Close voting as the results presentation begins, so the standings are frozen before they
+            // are computed and shown (the End step closes it again as a safety net).
+            app.compos.allowVoting(compo.id, false).bind()
             val results = app.votes.getResults().bind().filter { it.compoId == compo.id }
             val grouped = CompoResult.groupResults(results).values.firstOrNull().orEmpty()
 
@@ -192,6 +195,9 @@ sealed interface ResultsStep {
         )
 
         override suspend fun activate(app: AppServices) {
+            // Close voting when the results go on the big screen, otherwise voters could keep changing
+            // votes on a compo whose standings have already been published.
+            app.compos.allowVoting(compoId, false)
             app.compos.publishResults(compoId, true)
             app.compos.setVisible(compoId, true)
         }

--- a/src/main/kotlin/party/jml/partyboi/data/ApiRespond.kt
+++ b/src/main/kotlin/party/jml/partyboi/data/ApiRespond.kt
@@ -12,6 +12,8 @@ import io.ktor.server.response.*
 import kotlinx.serialization.json.Json
 import party.jml.partyboi.auth.userSession
 import party.jml.partyboi.form.Form
+import party.jml.partyboi.form.MAX_FORM_FIELD_SIZE
+import party.jml.partyboi.form.multipartSizeLimit
 import party.jml.partyboi.system.AppResult
 import party.jml.partyboi.templates.Renderable
 import party.jml.partyboi.templates.respondAndCatchEither
@@ -50,15 +52,22 @@ suspend inline fun <reified T> ApplicationCall.jsonRespond(noinline block: suspe
     }
 }
 
-suspend inline fun <reified T : Validateable<T>> ApplicationCall.receiveForm(formFieldLimit: Long): AppResult<Form<T>> =
-    Form.fromParameters<T>(receiveMultipart(formFieldLimit = formFieldLimit))
+suspend inline fun <reified T : Validateable<T>> ApplicationCall.receiveForm(maxUploadSize: Long): AppResult<Form<T>> =
+    try {
+        Form.fromParameters<T>(receiveMultipart(formFieldLimit = multipartSizeLimit(maxUploadSize)))
+    } catch (e: Exception) {
+        // An oversized body is rejected by Ktor's multipart parser; surface it as a form error.
+        FormError(e.message ?: "Upload failed").left()
+    }
 
 suspend inline fun <reified T : Validateable<T>> ApplicationCall.processForm(
     handleForm: suspend Raise<AppError>.(data: T) -> Renderable,
     crossinline handleError: suspend Raise<AppError>.(formWithErrors: Form<T>) -> Renderable,
-    formFieldLimit: Long = -1L,
+    // Text-only forms cap each field (and the whole body) at a small size; routes that accept file
+    // uploads pass app.config.maxFileUploadSize explicitly.
+    maxUploadSize: Long = MAX_FORM_FIELD_SIZE,
 ) {
-    receiveForm<T>(formFieldLimit).fold(
+    receiveForm<T>(maxUploadSize).fold(
         { respondPage(it) },
         { form ->
             val result = form.validated().fold(

--- a/src/main/kotlin/party/jml/partyboi/data/AppError.kt
+++ b/src/main/kotlin/party/jml/partyboi/data/AppError.kt
@@ -17,6 +17,11 @@ interface AppError : Renderable {
     val statusCode: HttpStatusCode
     val throwable: Throwable?
 
+    // Renderable.statusCode() defaults to 200 OK. Without this override, respondPage() rendered every
+    // error page (NotFound, Unauthorized, …) with a 200 status, ignoring the real statusCode below —
+    // only the API path (apiRespond) used it. Surface the real status to the page path too.
+    override fun statusCode(): HttpStatusCode = statusCode
+
     override fun getContent(user: User?, path: String): String {
         val className = this::class.simpleName ?: "AppError"
         val page = Page("Error") {

--- a/src/main/kotlin/party/jml/partyboi/entries/EntriesRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EntriesRouting.kt
@@ -158,7 +158,7 @@ fun Application.configureEntriesRouting(app: AppServices) {
                 val fileId = call.parameterUUID("fileId").bind()
                 val user = call.optionalUserSession(app)
                 val entry = app.entries.getByFileId(fileId).bind()
-                if (user?.let { it.isAdmin || it.id === entry.userId } == true
+                if (user?.let { it.isAdmin || it.id == entry.userId } == true
                     || app.compos.getById(entry.compoId).bind().publicResults
                 ) {
                     app.files.getById(fileId).bind()

--- a/src/main/kotlin/party/jml/partyboi/entries/EntriesRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EntriesRouting.kt
@@ -107,7 +107,7 @@ fun Application.configureEntriesRouting(app: AppServices) {
                 {
                     renderEntriesPage(call.userSession(app), newEntryForm = it).bind()
                 },
-                app.config.maxFileUploadSize
+                maxUploadSize = app.config.maxFileUploadSize,
             )
         }
 
@@ -214,7 +214,7 @@ fun Application.configureEntriesRouting(app: AppServices) {
                         entryUpdateForm = it
                     ).bind()
                 },
-                app.config.maxFileUploadSize
+                maxUploadSize = app.config.maxFileUploadSize,
             )
         }
 
@@ -239,7 +239,8 @@ fun Application.configureEntriesRouting(app: AppServices) {
                         user = call.userSession(app),
                         previewForm = it
                     ).bind()
-                }
+                },
+                maxUploadSize = app.config.maxFileUploadSize,
             )
         }
     }

--- a/src/main/kotlin/party/jml/partyboi/entries/EntryRepository.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EntryRepository.kt
@@ -113,8 +113,8 @@ class EntryRepository(app: AppServices) : Service(app) {
         )
     }
 
-    suspend fun add(newEntry: NewEntry): AppResult<Entry> =
-        db.transaction {
+    suspend fun add(newEntry: NewEntry): AppResult<Entry> = either {
+        val (entry, storedFile) = db.transaction {
             either {
                 val compo = app.compos.getById(newEntry.compoId, this@transaction).bind()
                 if (compo.requireFile == true && !newEntry.file.isDefined) {
@@ -133,19 +133,32 @@ class EntryRepository(app: AppServices) : Service(app) {
                     ).map(Entry.fromRow)
                 ).bind()
 
-                if (newEntry.file.isDefined) {
-                    val storedFile = storeFile(newEntry.file, entry.id, this@transaction).bind()
-
-                    app.previews.scanForScreenshotSource(storedFile)?.let { source ->
-                        app.previews.store(entry.id, source)
-                    }
+                val storedFile = if (newEntry.file.isDefined) {
+                    storeFile(newEntry.file, entry.id, this@transaction).bind()
+                } else {
+                    null
                 }
 
-                entry
+                entry to storedFile
             }
-        }.onRight {
-            app.signals.emit(Signal.compoContentUpdated(newEntry.compoId, app.time))
+        }.bind()
+
+        app.signals.emit(Signal.compoContentUpdated(newEntry.compoId, app.time))
+
+        // Generate the entry preview only after the transaction has committed: preview generation
+        // runs image/audio processing and persists the preview on its own connection, so it must see
+        // the committed entry/file rows — otherwise the preview INSERT hits a foreign-key violation.
+        // The preview is best-effort: a failure here is logged but must not fail entry submission.
+        storedFile?.let { file ->
+            app.previews.scanForScreenshotSource(file)?.let { source ->
+                app.previews.store(entry.id, source).onLeft {
+                    log.error("Failed to generate preview for entry {}: {}", entry.id, it.message)
+                }
+            }
         }
+
+        entry
+    }
 
     suspend fun update(entry: EntryUpdate, userId: UUID): AppResult<Entry> = either {
         val previousVersion = getById(entry.id).bind()
@@ -194,14 +207,14 @@ class EntryRepository(app: AppServices) : Service(app) {
     suspend fun delete(entryId: UUID): AppResult<Unit> = either {
         val entry = getById(entryId).bind()
         db.use {
-            updateOne(queryOf("DELETE FROM entry WHERE id = ? CASCADE", entryId))
+            updateOne(queryOf("DELETE FROM entry WHERE id = ?", entryId))
         }.onRight {
             app.signals.emit(Signal.compoContentUpdated(entry.compoId, app.time))
         }
     }
 
     suspend fun deleteAll(): AppResult<Unit> = db.use {
-        exec(queryOf("DELETE FROM entry CASCADE"))
+        exec(queryOf("DELETE FROM entry"))
     }
 
     suspend fun setQualified(entryId: UUID, state: Boolean): AppResult<Unit> =

--- a/src/main/kotlin/party/jml/partyboi/form/FileUpload.kt
+++ b/src/main/kotlin/party/jml/partyboi/form/FileUpload.kt
@@ -80,6 +80,19 @@ data class FileUpload(
     }
 }
 
+// A sensible default upload limit for forms that only carry text fields — Ktor's formFieldLimit
+// bounds both the whole multipart body and each individual part, so this caps non-file form fields.
+const val MAX_FORM_FIELD_SIZE = 1024L * 1024L // 1 MB
+
+// Fallback upload limit when files.maxSize is not configured, so uploads are never truly unbounded.
+const val DEFAULT_MAX_UPLOAD_SIZE = 2L * 1024 * 1024 * 1024 // 2 GB
+
+// The size limit handed to Ktor's receiveMultipart(formFieldLimit). Ktor uses it to bound the whole
+// multipart body and each individual part, so it must be at least the largest allowed file — and
+// must never be unlimited (-1), which is what an unconfigured files.maxSize used to produce.
+fun multipartSizeLimit(configuredMaxFileSize: Long): Long =
+    if (configuredMaxFileSize > 0) configuredMaxFileSize else DEFAULT_MAX_UPLOAD_SIZE
+
 suspend fun MultiPartData.collect(): Pair<Map<String, List<String>>, Map<String, List<FileUpload>>> {
     val stringParams = MapCollector<String, String>()
     val fileParams = MapCollector<String, FileUpload>()
@@ -97,7 +110,8 @@ suspend fun MultiPartData.collect(): Pair<Map<String, List<String>>, Map<String,
                     part.provider().copyAndClose(tempFile.writeChannel())
                     fileParams.add(
                         name, FileUpload(
-                            name = part.originalFileName ?: throw Error("File name missing for parameter '$name'"),
+                            name = part.originalFileName
+                                ?: throw IllegalArgumentException("File name missing for parameter '$name'"),
                             tempFile = tempFile,
                         )
                     )

--- a/src/main/kotlin/party/jml/partyboi/form/Form.kt
+++ b/src/main/kotlin/party/jml/partyboi/form/Form.kt
@@ -100,7 +100,7 @@ class Form<T : Validateable<T>>(
                 } as T
 
                 of(data).right()
-            } catch (e: Error) {
+            } catch (e: Exception) {
                 FormError(e.message ?: e.toString()).left()
             }
     }

--- a/src/main/kotlin/party/jml/partyboi/infoscreen/InfoScreenService.kt
+++ b/src/main/kotlin/party/jml/partyboi/infoscreen/InfoScreenService.kt
@@ -26,7 +26,7 @@ import kotlin.io.path.readText
 class InfoScreenService(app: AppServices) : Service(app) {
     private val repository = InfoScreenRepository(app)
     private val state = property("state", InfoScreenState.Empty).toState()
-    private var autoRunScheduler: TimerTask? = null
+    private var autoRunTimer: Timer? = null
     private val autoRunOn = property("autoRunOn", false)
 
     init {
@@ -63,7 +63,7 @@ class InfoScreenService(app: AppServices) : Service(app) {
             repository.deleteSlideSet(id)
         }
 
-    fun currentState(): Pair<InfoScreenState, Boolean> = Pair(state.value, autoRunScheduler != null)
+    fun currentState(): Pair<InfoScreenState, Boolean> = Pair(state.value, autoRunTimer != null)
     fun currentSlide(): Slide<*> = state.value.slide
 
     fun waitForNext(): Flow<InfoScreenState> = state.waitForNext()
@@ -124,8 +124,8 @@ class InfoScreenService(app: AppServices) : Service(app) {
     suspend fun setRunOrder(id: UUID, order: Int) = repository.setRunOrder(id, order)
 
     suspend fun stopSlideSet() {
-        autoRunScheduler?.cancel()
-        autoRunScheduler = null
+        autoRunTimer?.cancel()
+        autoRunTimer = null
         autoRunOn.set(false)
     }
 
@@ -136,9 +136,15 @@ class InfoScreenService(app: AppServices) : Service(app) {
         }
 
     suspend fun startAutoRunScheduler() {
-        autoRunScheduler = Timer().schedule(10000, 10000) {
-            runBlocking {
-                showNext()
+        // Cancel any running scheduler first, otherwise the old Timer's thread is leaked and both keep
+        // advancing the slides. Store the Timer (not just the task) so it can be fully cancelled, and
+        // run it on a daemon thread so a leftover scheduler can never keep the JVM alive.
+        autoRunTimer?.cancel()
+        autoRunTimer = Timer("infoscreen-autorun", true).apply {
+            schedule(10000, 10000) {
+                runBlocking {
+                    showNext()
+                }
             }
         }
         autoRunOn.set(true)

--- a/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenRouting.kt
@@ -14,6 +14,7 @@ import party.jml.partyboi.data.*
 import party.jml.partyboi.entries.FileDesc
 import party.jml.partyboi.form.Form
 import party.jml.partyboi.form.collect
+import party.jml.partyboi.form.multipartSizeLimit
 import party.jml.partyboi.infoscreen.NewSlideSet
 import party.jml.partyboi.infoscreen.SlideSetRow
 import party.jml.partyboi.infoscreen.slides.ImageSlide
@@ -206,7 +207,14 @@ fun Application.configureAdminScreenRouting(app: AppServices) {
 
         post("/admin/screen/{slideSet}/new/imageslide/upload") {
             val slideSetName = call.parameterString("slideSet").getOrNull() ?: return@post
-            val (_, files) = call.receiveMultipart(app.config.maxFileUploadSize).collect()
+            val (_, files) = try {
+                call.receiveMultipart(formFieldLimit = multipartSizeLimit(app.config.maxFileUploadSize)).collect()
+            } catch (e: Exception) {
+                call.respondEither {
+                    renderImageSlidesPicker(slideSetName.right(), uploadError = e.message ?: "Upload failed").bind()
+                }
+                return@post
+            }
             val uploadedFiles = (files["files"] ?: emptyList()).filter { it.isDefined }
 
             if (uploadedFiles.isEmpty()) {

--- a/src/main/kotlin/party/jml/partyboi/schedule/ICalendar.kt
+++ b/src/main/kotlin/party/jml/partyboi/schedule/ICalendar.kt
@@ -35,7 +35,7 @@ object ICalendar {
         override fun toString(): String = ics.toString()
 
         fun append(line: String) {
-            ics.append("$line$CRLF")
+            ics.append(fold(line)).append(CRLF)
         }
 
         fun obj(name: String, block: ICalendarDsl.() -> Unit) {
@@ -47,8 +47,43 @@ object ICalendar {
         fun calendar(block: ICalendarDsl.() -> Unit) = obj("VCALENDAR", block)
         fun event(block: ICalendarDsl.() -> Unit) = obj("VEVENT", block)
 
-        fun prop(key: String, value: String) = append("$key:$value")
+        fun prop(key: String, value: String) = append("$key:${escapeText(value)}")
         fun prop(key: String, time: Instant) = append("$key:${formatTime(time)}")
+
+        // RFC 5545 §3.3.11: backslash, semicolon, comma and newlines are special in TEXT values and
+        // must be escaped. Escape the backslash first so the escapes added afterwards aren't doubled.
+        private fun escapeText(value: String): String =
+            value
+                .replace("\\", "\\\\")
+                .replace("\r\n", "\\n")
+                .replace("\n", "\\n")
+                .replace("\r", "\\n")
+                .replace(";", "\\;")
+                .replace(",", "\\,")
+
+        // RFC 5545 §3.1: a content line is limited to 75 octets; longer lines must be folded by
+        // inserting CRLF followed by a single space. Fold on character boundaries so multi-byte
+        // UTF-8 sequences are never split across a fold.
+        private fun fold(line: String): String {
+            val maxOctets = 75
+            val sb = StringBuilder()
+            var octets = 0
+            var i = 0
+            while (i < line.length) {
+                val codePoint = line.codePointAt(i)
+                val charCount = Character.charCount(codePoint)
+                val piece = line.substring(i, i + charCount)
+                val pieceOctets = piece.toByteArray(Charsets.UTF_8).size
+                if (octets + pieceOctets > maxOctets) {
+                    sb.append(CRLF).append(' ')
+                    octets = 1 // the continuation line begins with the inserted space
+                }
+                sb.append(piece)
+                octets += pieceOctets
+                i += charCount
+            }
+            return sb.toString()
+        }
 
         private fun formatTime(time: Instant): String =
             time

--- a/src/main/kotlin/party/jml/partyboi/triggers/TriggerRepository.kt
+++ b/src/main/kotlin/party/jml/partyboi/triggers/TriggerRepository.kt
@@ -1,16 +1,19 @@
 package party.jml.partyboi.triggers
 
+import arrow.core.Either
 import arrow.core.flatten
 import arrow.core.raise.either
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.time.toKotlinInstant
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import party.jml.partyboi.AppServices
 import party.jml.partyboi.Service
+import party.jml.partyboi.data.InternalServerError
 import party.jml.partyboi.data.UUIDSerializer
 import party.jml.partyboi.data.UUIDv7
 import party.jml.partyboi.db.*
@@ -26,7 +29,18 @@ class TriggerRepository(app: AppServices) : Service(app) {
     private val db = app.db
 
     suspend fun start() {
-        app.signals.flow.collect { execute(it) }
+        app.signals.flow.collect { signal ->
+            try {
+                execute(signal)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (error: Throwable) {
+                // A failure while handling one signal must never tear down the collector — that would
+                // silently disable all future triggers (e.g. auto open/close of voting and submitting)
+                // for the rest of the process lifetime.
+                log.error("Trigger handling failed for signal {}", signal, error)
+            }
+        }
     }
 
     suspend fun add(signal: Signal, action: Action, tx: TransactionalSession? = null): AppResult<TriggerRow> =
@@ -106,7 +120,10 @@ class TriggerRepository(app: AppServices) : Service(app) {
     }
 
     private suspend fun executeTrigger(trigger: TriggerRow, logTime: Instant): AppResult<Unit> {
-        return trigger.getAction().apply(app).fold(
+        val result = either {
+            trigger.getAction().bind().apply(app).bind()
+        }
+        return result.fold(
             { error -> setFailed(trigger.triggerId, logTime, error.message) },
             { _ -> setSuccessful(trigger.triggerId, logTime) }
         )
@@ -139,11 +156,14 @@ sealed class TriggerRow {
     abstract val description: String
     abstract val enabled: Boolean
 
-    fun getAction(): Action = when (triggerType) {
-        OpenCloseVoting::class.qualifiedName -> Json.decodeFromString<OpenCloseVoting>(actionJson)
-        OpenCloseSubmitting::class.qualifiedName -> Json.decodeFromString<OpenCloseSubmitting>(actionJson)
-        else -> TODO("JSON decoding not implemented for $triggerType")
-    }
+    fun getAction(): AppResult<Action> =
+        Either.catch {
+            when (triggerType) {
+                OpenCloseVoting::class.qualifiedName -> Json.decodeFromString<OpenCloseVoting>(actionJson)
+                OpenCloseSubmitting::class.qualifiedName -> Json.decodeFromString<OpenCloseSubmitting>(actionJson)
+                else -> error("Unknown trigger action type: $triggerType")
+            }
+        }.mapLeft { InternalServerError(it) }
 
     companion object {
         val fromRow: (Row) -> TriggerRow = { row ->

--- a/src/main/kotlin/party/jml/partyboi/voting/VoteKeyRepository.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/VoteKeyRepository.kt
@@ -106,9 +106,9 @@ class VoteKeyRepository(app: AppServices) : Service(app) {
             .one(queryOf("SELECT true FROM votekey WHERE key = ?", voteKey.toString()).map(asBoolean))
             .isRight()
         if (exists) {
-            generateTicket(tx, keySet, remainingAttempts - 1)
+            generateTicket(tx, keySet, remainingAttempts - 1).bind()
         } else {
-            insertVoteKey(userId = null, voteKey, keySet, tx)
+            insertVoteKey(userId = null, voteKey, keySet, tx).bind()
         }
     }
 

--- a/src/main/kotlin/party/jml/partyboi/voting/VoteRepository.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/VoteRepository.kt
@@ -83,6 +83,7 @@ class VoteRepository(app: AppServices) : Service(app) {
             LEFT JOIN effective_vote ev ON ev.entry_id = entry.id
             JOIN compo ON compo.id = entry.compo_id
             WHERE qualified
+            AND NOT manual_results
             ${if (onlyPublic) "AND public_results" else ""}
             GROUP BY compo_id, compo.name, entry.id, title, author
             ORDER BY compo_id, points DESC, entry_id

--- a/src/main/kotlin/party/jml/partyboi/voting/VoteService.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/VoteService.kt
@@ -2,6 +2,7 @@ package party.jml.partyboi.voting
 
 import arrow.core.*
 import arrow.core.raise.either
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.updateAndGet
 import party.jml.partyboi.AppServices
@@ -24,13 +25,23 @@ class VoteService(app: AppServices) : Service(app) {
     private val live = MutableStateFlow(LiveVoteState.Empty)
 
     suspend fun start() {
-        app.signals.flow.collect {
-            if (it.type == SignalType.propertyUpdated && it.target == "SettingsService.voteKeyEmailList") {
-                app.settings.automaticVoteKeys.get().onRight { autoKeys ->
-                    if (autoKeys == AutomaticVoteKeys.PER_EMAIL) {
-                        app.voteKeys.grantVotingRightsByEmail()
+        app.signals.flow.collect { signal ->
+            try {
+                if (signal.type == SignalType.propertyUpdated && signal.target == "SettingsService.voteKeyEmailList") {
+                    app.settings.automaticVoteKeys.get().onRight { autoKeys ->
+                        if (autoKeys == AutomaticVoteKeys.PER_EMAIL) {
+                            app.voteKeys.grantVotingRightsByEmail().onLeft {
+                                log.error("Failed to grant voting rights by email: {}", it.message)
+                            }
+                        }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (error: Throwable) {
+                // A failure while handling one signal must never tear down the collector — that would
+                // silently stop automatic vote-key granting for the rest of the process lifetime.
+                log.error("Vote signal handling failed for signal {}", signal, error)
             }
         }
     }

--- a/src/main/kotlin/party/jml/partyboi/workqueue/WorkQueueRepository.kt
+++ b/src/main/kotlin/party/jml/partyboi/workqueue/WorkQueueRepository.kt
@@ -35,13 +35,14 @@ class WorkQueueRepository(val app: AppServices) {
             queryOf(
                 """
             UPDATE task
-            SET state = 'Working', started_at = now()
+            SET state = 'Working', started_at = now(), attempts = attempts + 1
             WHERE id IN (
             	SELECT id
             	FROM task
             	WHERE state = 'Pending'
             	ORDER BY created_at
             	LIMIT 1
+            	FOR UPDATE SKIP LOCKED
             )
             RETURNING *
         """.trimIndent()
@@ -49,8 +50,22 @@ class WorkQueueRepository(val app: AppServices) {
         ).flatten()
     }
 
-    suspend fun cancel(): AppResult<Unit> = db.use {
-        exec(queryOf("UPDATE task SET state = 'Discarded', finished_at = now() WHERE state = 'Working'"))
+    // Tasks left in 'Working' state were interrupted by a worker crash/restart (a running worker
+    // always moves a task to a terminal state itself). Requeue the ones that still have attempts left
+    // so they get retried, and give up on the rest — a task that keeps killing the worker must not be
+    // requeued forever. Order matters: fail the exhausted ones before requeuing the remaining Working.
+    suspend fun recoverStalledTasks(): AppResult<Unit> = db.use {
+        either {
+            exec(
+                queryOf(
+                    "UPDATE task SET state = 'Failed', finished_at = now() WHERE state = 'Working' AND attempts >= ?",
+                    MAX_ATTEMPTS,
+                )
+            ).bind()
+            exec(
+                queryOf("UPDATE task SET state = 'Pending', started_at = NULL WHERE state = 'Working'")
+            ).bind()
+        }
     }
 
     suspend fun setState(id: UUID, state: TaskState) = db.use {
@@ -74,6 +89,11 @@ class WorkQueueRepository(val app: AppServices) {
     suspend fun getById(id: UUID): AppResult<TaskRow> = db.use {
         one(queryOf("SELECT * FROM task WHERE id = ?", id).map(TaskRow.fromRow)).flatten()
     }
+
+    companion object {
+        // How many times a task may be claimed before a crash-interrupted run is given up on.
+        const val MAX_ATTEMPTS = 3
+    }
 }
 
 data class TaskRow(
@@ -82,7 +102,8 @@ data class TaskRow(
     val createdAt: Instant,
     val startedAt: Instant?,
     val finishedAt: Instant?,
-    val state: TaskState
+    val state: TaskState,
+    val attempts: Int,
 ) {
     companion object {
         val fromRow: (Row) -> AppResult<TaskRow> = { row ->
@@ -94,6 +115,7 @@ data class TaskRow(
                     startedAt = row.instantOrNull("started_at")?.toKotlinInstant(),
                     finishedAt = row.instantOrNull("finished_at")?.toKotlinInstant(),
                     state = TaskState.valueOf(row.string("state")),
+                    attempts = row.int("attempts"),
                 )
             }.mapLeft { InternalServerError(it) }
         }

--- a/src/main/kotlin/party/jml/partyboi/workqueue/WorkQueueService.kt
+++ b/src/main/kotlin/party/jml/partyboi/workqueue/WorkQueueService.kt
@@ -11,11 +11,10 @@ class WorkQueueService(val app: AppServices) : Logging() {
     suspend fun addTask(task: Task) = repository.add(task)
 
     suspend fun start() {
-        repository.cancel()
+        repository.recoverStalledTasks().onLeft { log.error("Failed to recover stalled tasks", it.throwable) }
         while (true) {
             try {
                 repository.takeNext().fold({
-                    repository.cancel()
                     delay(1000)
                 }, { taskRow ->
                     val success = try {

--- a/src/main/resources/db/migrations/V0038__cascade_delete_preview.sql
+++ b/src/main/resources/db/migrations/V0038__cascade_delete_preview.sql
@@ -1,0 +1,7 @@
+-- The preview.entry_id foreign key was created without an ON DELETE rule (V0029), so deleting an
+-- entry that has a generated preview failed with a foreign-key violation. (The admin delete path
+-- additionally used invalid "DELETE ... CASCADE" SQL, which never cascades.) Match the cascade rule
+-- already used by entry_file (V0027) and vote so an entry and its preview are removed together.
+ALTER TABLE "preview"
+    DROP CONSTRAINT "preview_entry_id_fkey",
+    ADD CONSTRAINT "preview_entry_id_fkey" FOREIGN KEY ("entry_id") REFERENCES "entry" ("id") ON DELETE CASCADE;

--- a/src/main/resources/db/migrations/V0039__add_attempts_to_task.sql
+++ b/src/main/resources/db/migrations/V0039__add_attempts_to_task.sql
@@ -1,0 +1,3 @@
+-- Track how many times a task has been claimed for execution so a task that was interrupted by a
+-- worker crash/restart can be retried a bounded number of times instead of being discarded outright.
+ALTER TABLE task ADD COLUMN attempts integer NOT NULL DEFAULT 0;

--- a/src/main/resources/tests.yaml
+++ b/src/main/resources/tests.yaml
@@ -30,3 +30,7 @@ files:
 
 email:
   mock: "true"
+
+# The work-queue worker would consume/process tasks that tests set up and assert on.
+workQueue:
+  enabled: "false"

--- a/src/main/resources/tests.yaml
+++ b/src/main/resources/tests.yaml
@@ -27,6 +27,9 @@ files:
   entries: "$FILES_ENTRIES:./data/test/entries"
   assets: "$FILES_ASSETS:./data/test/assets"
   screenshots: "$FILES_SCREENSHOTS:./data/test/screenshots"
+  # Small cap so the upload-size limit can be exercised without multi-gigabyte test files. Kept above
+  # the 1 MB per-form-field cap so that limit can be tested independently.
+  maxSize: "5MB"
 
 email:
   mock: "true"

--- a/src/test/kotlin/party/jml/EntryLifecycleTest.kt
+++ b/src/test/kotlin/party/jml/EntryLifecycleTest.kt
@@ -1,0 +1,93 @@
+package party.jml
+
+import arrow.core.raise.either
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import party.jml.partyboi.AppServices
+import party.jml.partyboi.compos.NewCompo
+import party.jml.partyboi.data.UUIDv7
+import party.jml.partyboi.entries.NewEntry
+import party.jml.partyboi.form.FileUpload
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EntryLifecycleTest : PartyboiTester {
+
+    // Regression for the "preview silently lost on entry creation" bug: the preview used to be
+    // written on a fresh connection inside the entry transaction (so it could not see the
+    // uncommitted entry row) and its result was discarded, leaving image entries with no preview.
+    @Test
+    fun testPreviewIsGeneratedForImageEntry() = test {
+        var previewExists: Boolean? = null
+
+        setupServices {
+            val app = this
+            either {
+                val user = addTestUser(app, "gfxuser").bind()
+                val compo = compos.add(NewCompo("Graphics", "")).bind()
+                val entry = entries.add(
+                    NewEntry(
+                        title = "Final Dog",
+                        author = "Naettiii",
+                        file = FileUpload.fromResource(app, "/images/image.zip")!!,
+                        compoId = compo.id,
+                        screenComment = "",
+                        orgComment = "",
+                        userId = user.id,
+                    )
+                ).bind()
+                previewExists = app.previews.get(entry.id).isRight()
+            }
+        }
+
+        it.login("gfxuser")
+
+        assertEquals(true, previewExists, "An image entry should have a generated preview after creation")
+    }
+
+    // Regression for the broken admin "delete entry" path: it used invalid "DELETE ... CASCADE" SQL
+    // (a syntax error in PostgreSQL), and even valid SQL would have been blocked by the preview
+    // foreign key that lacked an ON DELETE rule. Deleting an entry that has a preview must succeed.
+    @Test
+    fun testAdminCanDeleteEntryWithPreview() = test {
+        var appRef: AppServices? = null
+        var entryId: UUID = UUIDv7.Empty
+
+        setupServices {
+            val app = this
+            appRef = app
+            either {
+                addTestAdmin(app).bind()
+                val user = addTestUser(app, "submitter").bind()
+                val compo = compos.add(NewCompo("Graphics", "")).bind()
+                val entry = entries.add(
+                    NewEntry(
+                        title = "Doomed Entry",
+                        author = "Author",
+                        file = FileUpload.fromResource(app, "/images/image.zip")!!,
+                        compoId = compo.id,
+                        screenComment = "",
+                        orgComment = "",
+                        userId = user.id,
+                    )
+                ).bind()
+                entryId = entry.id
+                // The entry must actually have a preview, otherwise this would not exercise the
+                // cascade-delete of the preview row.
+                app.previews.get(entry.id).bind()
+            }
+        }
+
+        it.login("admin")
+
+        it.client.delete("/admin/compos/entries/$entryId").apply {
+            assertEquals(HttpStatusCode.OK, status, "admin delete should succeed, got ${status}: ${bodyAsText()}")
+        }
+
+        assertTrue(appRef!!.entries.getById(entryId).isLeft(), "entry should be deleted")
+        assertTrue(appRef!!.previews.get(entryId).isLeft(), "preview should be cascade-deleted with the entry")
+    }
+}

--- a/src/test/kotlin/party/jml/EntryLifecycleTest.kt
+++ b/src/test/kotlin/party/jml/EntryLifecycleTest.kt
@@ -1,6 +1,7 @@
 package party.jml
 
 import arrow.core.raise.either
+import io.ktor.client.plugins.cookies.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -12,6 +13,7 @@ import party.jml.partyboi.form.FileUpload
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class EntryLifecycleTest : PartyboiTester {
@@ -89,5 +91,55 @@ class EntryLifecycleTest : PartyboiTester {
 
         assertTrue(appRef!!.entries.getById(entryId).isLeft(), "entry should be deleted")
         assertTrue(appRef!!.previews.get(entryId).isLeft(), "preview should be cascade-deleted with the entry")
+    }
+
+    // Regression for the broken owner check in /entries/download/{fileId}: it compared the session
+    // user id with the entry's user id using === (reference equality), which is always false for two
+    // distinct UUID instances, so authors could not download their own entry before results were
+    // public. A non-owner must still be denied while results are not public.
+    //
+    // We assert on the Content-Disposition header (the file is served as an attachment) rather than
+    // the status code, because the denial path renders an HTML page that this SSR app returns with a
+    // 200 status — so the status alone cannot tell "file served" apart from "access denied page".
+    @Test
+    fun testOwnerCanDownloadOwnFileBeforeResultsArePublic() = test {
+        var ownerFileId: UUID = UUIDv7.Empty
+
+        setupServices {
+            val app = this
+            either {
+                val owner = addTestUser(app, "owner").bind()
+                val compo = compos.add(NewCompo("Demo", "")).bind() // results not public (default)
+                val entry = entries.add(
+                    NewEntry(
+                        title = "Owned Entry",
+                        author = "Owner",
+                        file = FileUpload.createTestData("owned.dat", 256),
+                        compoId = compo.id,
+                        screenComment = "",
+                        orgComment = "",
+                        userId = owner.id,
+                    )
+                ).bind()
+                ownerFileId = app.files.getLatest(entry.id, true).bind().id
+            }
+        }
+
+        // The author receives their own file as an attachment, even though results are not public.
+        it.login("owner")
+        assertEquals(
+            "attachment; filename=owned.dat",
+            it.client.get("/entries/download/$ownerFileId").headers[HttpHeaders.ContentDisposition],
+            "owner should receive their own file before results are public",
+        )
+
+        // A different (non-admin) user is still denied: the response is the access-denied page, not
+        // the file (no attachment Content-Disposition).
+        val other = TestHtmlClient(createClient { install(HttpCookies) })
+        other.login("otheruser")
+        assertNull(
+            other.client.get("/entries/download/$ownerFileId").headers[HttpHeaders.ContentDisposition],
+            "a non-owner must not receive the file while results are not public",
+        )
     }
 }

--- a/src/test/kotlin/party/jml/EntryLifecycleTest.kt
+++ b/src/test/kotlin/party/jml/EntryLifecycleTest.kt
@@ -142,4 +142,19 @@ class EntryLifecycleTest : PartyboiTester {
             "a non-owner must not receive the file while results are not public",
         )
     }
+
+    // Regression for the respondPage status-code bug: AppError overrode only the statusCode property,
+    // not Renderable.statusCode(), so respondPage rendered every error page with a 200 status. A page
+    // route that raises NotFound must respond 404.
+    @Test
+    fun testMissingFileDownloadReturns404() = test {
+        setupServices { either { addTestUser(this@setupServices, "u").bind() } }
+
+        it.login("u")
+        assertEquals(
+            HttpStatusCode.NotFound,
+            it.client.get("/entries/download/${UUID.randomUUID()}").status,
+            "downloading a non-existent file should return 404, not 200",
+        )
+    }
 }

--- a/src/test/kotlin/party/jml/HostFileTraversalTest.kt
+++ b/src/test/kotlin/party/jml/HostFileTraversalTest.kt
@@ -1,0 +1,66 @@
+package party.jml
+
+import arrow.core.raise.either
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import party.jml.partyboi.compos.NewCompo
+import party.jml.partyboi.data.UUIDv7
+import party.jml.partyboi.entries.NewEntry
+import party.jml.partyboi.form.FileUpload
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class HostFileTraversalTest : PartyboiTester {
+
+    // Regression: /admin/host/{fileId}/{path...} resolved the {path...} wildcard against the extracted
+    // entry directory without normalising it or checking containment, so "../../../../etc/passwd"
+    // escaped the directory and served arbitrary files. The path must be confined to the directory.
+    @Test
+    fun testHostFileRejectsPathTraversal() = test {
+        var fileId: UUID = UUIDv7.Empty
+
+        setupServices {
+            val app = this
+            either {
+                addTestAdmin(app).bind()
+                val user = addTestUser(app, "submitter").bind()
+                val compo = compos.add(NewCompo("Demo", "")).bind()
+                val entry = entries.add(
+                    NewEntry(
+                        title = "Hosted",
+                        author = "A",
+                        file = FileUpload.createTestData("hosted.dat", 256),
+                        compoId = compo.id,
+                        screenComment = "",
+                        orgComment = "",
+                        userId = user.id,
+                    )
+                ).bind()
+                fileId = app.files.getLatest(entry.id, true).bind().id
+            }
+        }
+
+        it.login("admin")
+
+        // Hosting the entry's own extracted directory works.
+        assertEquals(
+            HttpStatusCode.OK,
+            it.client.get("/admin/host/$fileId").status,
+            "an admin should be able to host the entry's own files",
+        )
+
+        // "../../../../../../../etc/passwd" (url-encoded) must not escape the directory.
+        val traversal = "%2e%2e%2f".repeat(8) + "etc%2fpasswd"
+        val resp = it.client.get("/admin/host/$fileId/$traversal")
+        val body = resp.bodyAsText()
+        assertEquals(
+            HttpStatusCode.NotFound,
+            resp.status,
+            "path traversal must be rejected (status ${resp.status})",
+        )
+        assertFalse(body.contains("root:"), "must not serve the contents of /etc/passwd")
+    }
+}

--- a/src/test/kotlin/party/jml/ICalendarTest.kt
+++ b/src/test/kotlin/party/jml/ICalendarTest.kt
@@ -1,0 +1,89 @@
+package party.jml
+
+import party.jml.partyboi.schedule.Event
+import party.jml.partyboi.schedule.ICalendar
+import java.util.UUID
+import kotlin.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ICalendarTest {
+
+    private fun event(name: String) = Event(
+        id = UUID.fromString("0190a0e0-0000-7000-8000-000000000001"),
+        name = name,
+        startTime = Instant.parse("2025-06-01T12:00:00Z"),
+        endTime = null,
+        visible = true,
+    )
+
+    private fun ics(name: String) = ICalendar.eventsToIcs(
+        hostname = "party.example",
+        instanceName = "Test Party",
+        events = listOf(event(name)),
+    )
+
+    // A comma in an event name (e.g. "Demo, Wild & Combined") used to be emitted verbatim, which
+    // corrupts the SUMMARY value for strict parsers. Commas and semicolons must be escaped.
+    @Test
+    fun testCommaAndSemicolonAreEscaped() {
+        val out = ics("Demo, Wild; Combined")
+        assertTrue(
+            out.contains("SUMMARY:Demo\\, Wild\\; Combined"),
+            "comma and semicolon must be escaped in SUMMARY:\n$out"
+        )
+    }
+
+    @Test
+    fun testBackslashIsEscaped() {
+        val out = ics("Back\\slash")
+        assertTrue(out.contains("SUMMARY:Back\\\\slash"), "backslash must be escaped:\n$out")
+    }
+
+    // Regression for the iCalendar injection vector: a newline in the event name must be escaped to
+    // a literal "\n" sequence, never emitted as a real line break that injects calendar components.
+    @Test
+    fun testNewlineCannotInjectCalendarComponents() {
+        val out = ics("Party\r\nBEGIN:VEVENT\r\nSUMMARY:Injected")
+        val structuralVevents = out.split(Regex("\\r\\n|\\n|\\r")).count { it == "BEGIN:VEVENT" }
+        assertEquals(1, structuralVevents, "event name newline injected an extra calendar component:\n$out")
+        assertTrue(
+            out.contains("""SUMMARY:Party\nBEGIN:VEVENT\nSUMMARY:Injected"""),
+            "newline must be escaped to a literal \\n:\n$out"
+        )
+    }
+
+    // RFC 5545 §3.1: no content line may exceed 75 octets.
+    @Test
+    fun testLongLinesAreFolded() {
+        val out = ics("A".repeat(200))
+        val tooLong = out.split("\r\n").filter { it.toByteArray(Charsets.UTF_8).size > 75 }
+        assertTrue(tooLong.isEmpty(), "content lines must be folded to <= 75 octets; offenders: $tooLong")
+        assertTrue(out.contains("\r\n A"), "a folded continuation line must start with a space:\n$out")
+    }
+
+    @Test
+    fun testMultiByteCharactersAreNotSplitAcrossFold() {
+        // 80 'ä' characters (2 octets each in UTF-8): folding must break on character boundaries so
+        // each physical line still decodes as valid UTF-8.
+        val out = ics("ä".repeat(80))
+        out.split("\r\n").forEach { line ->
+            assertEquals(
+                line,
+                String(line.toByteArray(Charsets.UTF_8), Charsets.UTF_8),
+                "a fold split a multi-byte UTF-8 sequence"
+            )
+            assertTrue(line.toByteArray(Charsets.UTF_8).size <= 75, "line exceeds 75 octets: $line")
+        }
+    }
+
+    @Test
+    fun testSkeletonIsWellFormed() {
+        val out = ics("Opening ceremony")
+        assertTrue(out.startsWith("BEGIN:VCALENDAR\r\n"), out)
+        assertTrue(out.trimEnd().endsWith("END:VCALENDAR"), out)
+        assertTrue(out.contains("BEGIN:VEVENT\r\n"), out)
+        assertTrue(out.contains("SUMMARY:Opening ceremony\r\n"), out)
+    }
+}

--- a/src/test/kotlin/party/jml/InfoScreenSchedulerTest.kt
+++ b/src/test/kotlin/party/jml/InfoScreenSchedulerTest.kt
@@ -1,0 +1,53 @@
+package party.jml
+
+import arrow.core.right
+import kotlinx.coroutines.delay
+import party.jml.partyboi.AppServices
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InfoScreenSchedulerTest : PartyboiTester {
+
+    // Regression: startAutoRunScheduler() overwrote the stored scheduler without cancelling the old
+    // one, and only ever kept a TimerTask, so each (re)start leaked a non-daemon Timer thread that
+    // kept advancing slides. Repeatedly starting and then stopping the scheduler must leave no extra
+    // Timer threads behind.
+    @Test
+    fun testAutoRunSchedulerDoesNotLeakTimerThreads() = test {
+        var appRef: AppServices? = null
+        setupServices {
+            appRef = this
+            Unit.right()
+        }
+
+        it.login() // force application startup so appRef is populated
+        val screen = appRef!!.screen
+
+        // Start from a known state and let any prior scheduler thread exit.
+        screen.stopSlideSet()
+        delay(200)
+        val before = timerThreadCount()
+
+        repeat(5) { screen.startAutoRunScheduler() }
+        screen.stopSlideSet()
+
+        // Cancelled Timer threads exit asynchronously; wait until they have, or give up after a while.
+        val deadline = before // capture for the message
+        var after = timerThreadCount()
+        repeat(40) {
+            if (after <= before) return@repeat
+            delay(50)
+            after = timerThreadCount()
+        }
+
+        assertEquals(
+            before,
+            after,
+            "repeatedly starting then stopping the auto-run scheduler leaked Timer threads ($deadline -> $after)",
+        )
+    }
+
+    // Count live java.util.Timer worker threads (the leaked ones are these, regardless of name).
+    private fun timerThreadCount(): Int =
+        Thread.getAllStackTraces().keys.count { it.isAlive && it.javaClass.name == "java.util.TimerThread" }
+}

--- a/src/test/kotlin/party/jml/ManualResultsTest.kt
+++ b/src/test/kotlin/party/jml/ManualResultsTest.kt
@@ -1,0 +1,74 @@
+package party.jml
+
+import arrow.core.raise.either
+import party.jml.partyboi.AppServices
+import party.jml.partyboi.compos.NewCompo
+import party.jml.partyboi.compos.NewManualResult
+import party.jml.partyboi.data.UUIDv7
+import party.jml.partyboi.entries.NewEntry
+import party.jml.partyboi.form.FileUpload
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ManualResultsTest : PartyboiTester {
+
+    // Regression: a manual-results compo that still had qualified entry rows had those entries counted
+    // by the vote-results query AND its manual rows by the manual-results query, so each compo showed
+    // up twice and groupResults mixed position-0 vote rows into the manual standings. The vote-results
+    // query must exclude manual-results compos.
+    @Test
+    fun testManualResultsCompoIsNotDoubleCounted() = test {
+        var appRef: AppServices? = null
+        var compoId = UUIDv7.Empty
+
+        setupServices {
+            val app = this
+            appRef = app
+            either {
+                val user = addTestUser(app).bind()
+                val compo = compos.add(NewCompo("Best Photo", "")).bind()
+                compoId = compo.id
+
+                // A qualified entry exists (e.g. it was submitted before the compo went manual).
+                val entry = entries.add(
+                    NewEntry(
+                        title = "Submitted Entry",
+                        author = "Bob",
+                        file = FileUpload.createTestData("photo.dat", 256),
+                        compoId = compo.id,
+                        screenComment = "",
+                        orgComment = "",
+                        userId = user.id,
+                    )
+                ).bind()
+                entries.setQualified(entry.id, true).bind()
+
+                // The compo is switched to manually-entered results, and a result is added.
+                compos.update(compo.copy(manualResults = true)).bind()
+                manualResults.add(
+                    NewManualResult(
+                        title = "Winner",
+                        author = "Alice",
+                        scoreText = "42 pts",
+                        screenComment = "",
+                        compoId = compo.id,
+                    )
+                ).bind()
+            }
+        }
+
+        it.login()
+
+        val results = appRef!!.votes.getResults().getOrNull().orEmpty().filter { it.compoId == compoId }
+        assertTrue(
+            results.all { it.isManual },
+            "a manual-results compo must not include vote-derived entry rows: $results",
+        )
+        assertEquals(
+            listOf("Winner"),
+            results.map { it.title },
+            "only the manual result should be listed for a manual-results compo",
+        )
+    }
+}

--- a/src/test/kotlin/party/jml/ResultsPublishingTest.kt
+++ b/src/test/kotlin/party/jml/ResultsPublishingTest.kt
@@ -1,0 +1,70 @@
+package party.jml
+
+import arrow.core.raise.either
+import party.jml.partyboi.AppServices
+import party.jml.partyboi.compos.NewCompo
+import party.jml.partyboi.compos.admin.ResultsStep
+import party.jml.partyboi.data.UUIDv7
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ResultsPublishingTest : PartyboiTester {
+
+    // Regression: advancing the on-screen results presentation to its final "End" step published the
+    // results and made the compo visible but left voting open, so voters could keep changing votes on
+    // a compo whose standings were already on the big screen. Publishing must also close voting.
+    @Test
+    fun testPublishingResultsClosesVoting() = test {
+        var appRef: AppServices? = null
+        var compoId = UUIDv7.Empty
+
+        setupServices {
+            appRef = this
+            either {
+                val compo = compos.add(NewCompo("Demo", "")).bind()
+                compoId = compo.id
+                compos.allowSubmit(compo.id, false).bind()
+                compos.allowVoting(compo.id, true).bind() // voting is open before results are shown
+            }
+        }
+
+        it.login()
+
+        // Advance the results presentation to the final step (results published on screen).
+        ResultsStep.End("Demo", compoId).activate(appRef!!)
+
+        val compo = appRef!!.compos.getById(compoId).getOrNull()!!
+        assertFalse(compo.allowVote, "publishing results must close voting")
+        assertTrue(compo.publicResults, "results must be published")
+        assertTrue(compo.visible, "compo must be made visible")
+    }
+
+    // Voting must also be closed as soon as the results presentation is started (the standings are
+    // frozen before they are computed), not only at the final publish step.
+    @Test
+    fun testStartingResultsPresentationClosesVoting() = test {
+        var appRef: AppServices? = null
+        var compoId = UUIDv7.Empty
+
+        setupServices {
+            appRef = this
+            either {
+                val compo = compos.add(NewCompo("Demo", "")).bind()
+                compoId = compo.id
+                compos.allowSubmit(compo.id, false).bind()
+                compos.allowVoting(compo.id, true).bind() // voting is open before the presentation starts
+            }
+        }
+
+        it.login()
+
+        val compo = appRef!!.compos.getById(compoId).getOrNull()!!
+        appRef!!.resultsRun.initResultsSteps(compo).getOrNull()
+
+        assertFalse(
+            appRef!!.compos.getById(compoId).getOrNull()!!.allowVote,
+            "starting the results presentation must close voting",
+        )
+    }
+}

--- a/src/test/kotlin/party/jml/TriggerActionTest.kt
+++ b/src/test/kotlin/party/jml/TriggerActionTest.kt
@@ -1,0 +1,47 @@
+package party.jml
+
+import party.jml.partyboi.data.UUIDv7
+import party.jml.partyboi.triggers.OpenCloseVoting
+import party.jml.partyboi.triggers.PendingTriggerRow
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class TriggerActionTest {
+
+    // Regression: decoding a trigger whose type is no longer recognised (e.g. an action class renamed
+    // in a refactor) used to throw NotImplementedError out of getAction(). Because the signal
+    // collector ran that unguarded, a single such row killed the collector and silently disabled all
+    // triggers for the rest of the process lifetime. getAction() must now return a Left instead.
+    @Test
+    fun testUnknownTriggerTypeYieldsLeftInsteadOfThrowing() {
+        val row = PendingTriggerRow(
+            triggerId = UUIDv7.Empty,
+            signal = "someSignal",
+            triggerType = "party.jml.partyboi.triggers.RenamedAction",
+            actionJson = "{}",
+            description = "stale trigger",
+            enabled = true,
+        )
+
+        val result = row.getAction()
+
+        assertTrue(result.isLeft(), "Unknown trigger type should yield a Left, not throw: $result")
+    }
+
+    @Test
+    fun testKnownTriggerTypeStillDecodes() {
+        val action = OpenCloseVoting(compoId = UUIDv7.Empty, open = true)
+        val row = PendingTriggerRow(
+            triggerId = UUIDv7.Empty,
+            signal = "someSignal",
+            triggerType = OpenCloseVoting::class.qualifiedName!!,
+            actionJson = action.toJson(),
+            description = "open voting",
+            enabled = true,
+        )
+
+        val result = row.getAction()
+
+        assertTrue(result.isRight(), "A known trigger type should still decode: $result")
+    }
+}

--- a/src/test/kotlin/party/jml/UploadSizeTest.kt
+++ b/src/test/kotlin/party/jml/UploadSizeTest.kt
@@ -1,0 +1,76 @@
+package party.jml
+
+import arrow.core.raise.either
+import party.jml.partyboi.AppServices
+import party.jml.partyboi.compos.NewCompo
+import party.jml.partyboi.data.UUIDv7
+import party.jml.partyboi.entries.NewEntry
+import party.jml.partyboi.form.DEFAULT_MAX_UPLOAD_SIZE
+import party.jml.partyboi.form.FileUpload
+import party.jml.partyboi.form.multipartSizeLimit
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UploadSizeTest : PartyboiTester {
+
+    // Regression: app.config.maxFileUploadSize was passed to receiveMultipart as formFieldLimit and
+    // defaulted to -1 (unlimited) when files.maxSize was unset, so uploads were unbounded. A file
+    // larger than the configured limit (5 MB in tests.yaml) must be rejected instead of stored.
+    @Test
+    fun testOversizedFileIsRejected() = test {
+        var appRef: AppServices? = null
+        var compoId = UUIDv7.Empty
+
+        setupServices {
+            appRef = this
+            either {
+                val demo = compos.add(NewCompo("Demo", "")).bind()
+                compos.setVisible(demo.id, true).bind()
+                compoId = demo.id
+            }
+        }
+
+        it.login()
+
+        // 2 MB: over the 1 MB text-form default but under the 5 MB file limit -> accepted (this also
+        // proves the entry upload route uses the large file limit, not the small form-field default).
+        it.post("/entries", entryWithFile("Accepted", 2_000_000, compoId)) {}
+
+        // Over the limit -> rejected. The server stops reading the oversized body, which can surface
+        // as a client-side connection error; either way no entry must be created.
+        try {
+            it.post("/entries", entryWithFile("Rejected", 6_000_000, compoId)) {}
+        } catch (_: Exception) {
+        }
+
+        assertEquals(
+            listOf("Accepted"),
+            compoEntryTitles(appRef!!, compoId),
+            "the oversized file upload must be rejected; only the under-limit entry should exist",
+        )
+    }
+
+    // The limit handed to Ktor's receiveMultipart must never be unlimited (-1), which is what an
+    // unconfigured files.maxSize used to produce. Text-only forms get this via the small default
+    // (see processForm), file forms via app.config.maxFileUploadSize — both go through this helper.
+    @Test
+    fun testMultipartLimitIsNeverUnlimited() {
+        assertEquals(DEFAULT_MAX_UPLOAD_SIZE, multipartSizeLimit(-1), "unset limit must fall back to a finite default")
+        assertEquals(DEFAULT_MAX_UPLOAD_SIZE, multipartSizeLimit(0), "zero limit must fall back to a finite default")
+        assertEquals(1_234_567L, multipartSizeLimit(1_234_567L), "a configured limit is used as-is")
+    }
+
+    private suspend fun compoEntryTitles(app: AppServices, compoId: UUID): List<String> =
+        app.entries.getEntriesForCompo(compoId).getOrNull().orEmpty().map { it.title }
+
+    private fun entryWithFile(title: String, fileBytes: Int, compoId: UUID) = NewEntry(
+        title = title,
+        author = "A",
+        file = FileUpload.createTestData("$title.dat", fileBytes),
+        compoId = compoId,
+        screenComment = "",
+        orgComment = "",
+        userId = UUIDv7.Empty,
+    )
+}

--- a/src/test/kotlin/party/jml/VoteKeyGenerationTest.kt
+++ b/src/test/kotlin/party/jml/VoteKeyGenerationTest.kt
@@ -1,0 +1,56 @@
+package party.jml
+
+import arrow.core.raise.either
+import io.ktor.client.request.*
+import party.jml.partyboi.db.exec
+import party.jml.partyboi.db.one
+import party.jml.partyboi.db.queryOf
+import party.jml.partyboi.system.AppResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VoteKeyGenerationTest : PartyboiTester {
+
+    // Regression for the swallowed-error bug in generateTicket: the recursive call and the
+    // insertVoteKey call were the last expression of an either {} that infers Unit, so their
+    // Either results were coerced to Unit and never bound. A failing insert was therefore silently
+    // dropped and createTickets reported success while committing nothing. Both calls must bind().
+    @Test
+    fun testCreateTicketsSurfacesInsertFailure() = test {
+        var okCount = -1
+        var failResult: AppResult<Unit>? = null
+
+        setupServices {
+            val app = this
+            either {
+                // Positive control: normal creation commits the requested number of tickets.
+                app.voteKeys.createTickets(3, "ok").bind()
+                okCount = app.db.useUnsafe {
+                    one(queryOf("SELECT count(*) AS c FROM votekey WHERE key_set = 'ok'").map { it.int("c") })
+                }.bind()
+
+                // Force every votekey insert to fail, then confirm createTickets reports the failure.
+                // NOT VALID skips the existing 'ok' rows but still enforces the check on new inserts.
+                app.db.useUnsafe {
+                    exec(queryOf("ALTER TABLE votekey ADD CONSTRAINT pb_reject_inserts CHECK (false) NOT VALID"))
+                }.bind()
+                try {
+                    failResult = app.voteKeys.createTickets(3, "fail")
+                } finally {
+                    app.db.useUnsafe {
+                        exec(queryOf("ALTER TABLE votekey DROP CONSTRAINT IF EXISTS pb_reject_inserts"))
+                    }.bind()
+                }
+            }
+        }
+
+        it.client.get("/") // trigger application startup so setupServices runs
+
+        assertEquals(3, okCount, "normal ticket creation should commit the requested tickets")
+        assertTrue(
+            failResult?.isLeft() == true,
+            "createTickets must surface an insert failure instead of swallowing it, got $failResult",
+        )
+    }
+}

--- a/src/test/kotlin/party/jml/WorkQueueRecoveryTest.kt
+++ b/src/test/kotlin/party/jml/WorkQueueRecoveryTest.kt
@@ -1,0 +1,78 @@
+package party.jml
+
+import arrow.core.raise.either
+import io.ktor.client.request.*
+import party.jml.partyboi.db.exec
+import party.jml.partyboi.db.queryOf
+import party.jml.partyboi.entries.FileDesc
+import party.jml.partyboi.workqueue.ExtractDuration
+import party.jml.partyboi.workqueue.TaskRow
+import party.jml.partyboi.workqueue.TaskState
+import party.jml.partyboi.workqueue.WorkQueueRepository
+import java.util.UUID
+import kotlin.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WorkQueueRecoveryTest : PartyboiTester {
+
+    // Regression: on startup the worker used to mark every 'Working' task 'Discarded', so a task that
+    // was mid-flight when the process crashed/redeployed was lost forever (e.g. a preview never
+    // generated). Stalled tasks must instead be requeued and retried a bounded number of times.
+    @Test
+    fun testStalledTasksAreRequeuedWithBoundedRetries() = test {
+        var requeued: TaskRow? = null
+        var exhausted: TaskRow? = null
+
+        setupServices {
+            val app = this
+            either {
+                val repo = app.workQueue.repository
+                val sampleTask = ExtractDuration(sampleFileDesc())
+
+                // A task interrupted mid-flight (Working) with attempts left -> requeued to Pending.
+                val a = repo.add(sampleTask).bind()
+                app.db.useUnsafe {
+                    exec(queryOf("UPDATE task SET state = 'Working', started_at = now(), attempts = 1 WHERE id = ?", a.id))
+                }.bind()
+
+                // A task that has used all its attempts -> Failed, not requeued (no infinite restart loop).
+                val b = repo.add(sampleTask).bind()
+                app.db.useUnsafe {
+                    exec(
+                        queryOf(
+                            "UPDATE task SET state = 'Working', started_at = now(), attempts = ? WHERE id = ?",
+                            WorkQueueRepository.MAX_ATTEMPTS,
+                            b.id,
+                        )
+                    )
+                }.bind()
+
+                repo.recoverStalledTasks().bind()
+
+                requeued = repo.getById(a.id).bind()
+                exhausted = repo.getById(b.id).bind()
+            }
+        }
+
+        it.client.get("/") // trigger application startup so setupServices runs
+
+        assertEquals(TaskState.Pending, requeued?.state, "an interrupted task with attempts left must be requeued")
+        assertEquals(1, requeued?.attempts, "requeue keeps the attempt count")
+        assertNull(requeued?.startedAt, "requeue clears started_at")
+        assertEquals(TaskState.Failed, exhausted?.state, "a task that exhausted its attempts must be failed, not requeued")
+    }
+
+    private fun sampleFileDesc() = FileDesc(
+        id = UUID.randomUUID(),
+        originalFilename = "sample.mp3",
+        deprecatedStorageFilename = null,
+        type = "audio",
+        size = 0L,
+        uploadedAt = Instant.parse("2025-01-01T00:00:00Z"),
+        checksum = null,
+        processed = false,
+        info = null,
+    )
+}


### PR DESCRIPTION
A batch of bug fixes found during a focused bug hunt. Each fix is small and self-contained, on its own commit, with a regression test that was **verified to fail without the fix** (and a few empirically confirmed, e.g. the `DELETE … CASCADE` SQL and the path traversal). Full suite green throughout: **33 classes, 102 tests, 0 failures**.

## Correctness
- **Entry deletion / triggers / previews** (`b9a228e`) — admin "delete entry" used `DELETE FROM entry WHERE id = ? CASCADE`, a PostgreSQL syntax error, so it always 500'd (migration adds the missing `ON DELETE CASCADE` to `preview.entry_id`); a single unrecognized trigger row killed the whole trigger subsystem for the process lifetime; auto-generated previews were silently lost on upload (preview write escaped the entry transaction).
- **Vote-ticket generation swallowed insert errors** (`d81c964`) — an `either {}` Unit-coercion dropped a failing insert, so `createTickets` reported success while writing fewer rows.
- **Work-queue recovery** (`0044197`) — crash-interrupted `Working` tasks were discarded on restart (lost media processing); now requeued with bounded retries (`attempts` column + `FOR UPDATE SKIP LOCKED`).
- **Manual-results compos double-counted** (`63bcef4`) — entries appeared in both the vote-results and manual-results lists, garbling `/results`.
- **Voting left open when results published** (`d36f037`) — the on-screen results presentation never closed voting; now closed when it starts (freezing standings) and again at the publish step.
- **iCalendar escaping & folding** (`fa7a42a`) — the public `.ics` feed didn't escape `, ; \ \n` or fold long lines (RFC 5545), corrupting feeds and allowing calendar injection via event names.
- **Error pages returned HTTP 200** (`6f13a14`) — `AppError` overrode the `statusCode` property but not `Renderable.statusCode()`, so every error page went out as 200.
- **Owner file-download check** (`e6f6702`) — used `===` (reference equality) on `UUID`, so authors could never download their own entry before results were public.

## Security
- **Admin file-hosting path traversal** (`9e74e8e`) — `/admin/host/{fileId}/{path...}` resolved the wildcard with no containment check, serving arbitrary files (e.g. `/etc/passwd`). Verified it served the file before the fix.
- **Unbounded uploads / form-field limits** (`a3c1907`) — the multipart limit defaulted to unlimited when `files.maxSize` was unset, and text-form fields shared the (large) file limit; now never unlimited, with a small per-form-field cap and the large limit only on file-upload routes.

## Resource leaks
- **Info-screen Timer leak** (`b5ec5cd`) — `startAutoRunScheduler` overwrote the scheduler without cancelling the old one and only kept the `TimerTask`, leaking non-daemon Timer threads that double-advanced slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)