### PR TITLE
Buffer the signal bus so bursts of signals aren't dropped

### DIFF
--- a/src/main/kotlin/party/jml/partyboi/signals/Signal.kt
+++ b/src/main/kotlin/party/jml/partyboi/signals/Signal.kt
@@ -1,7 +1,7 @@
 package party.jml.partyboi.signals
 
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
 import kotlin.time.Clock
@@ -13,7 +13,17 @@ import party.jml.partyboi.system.TimeService
 import java.util.*
 
 class SignalService(app: AppServices) : Service(app) {
-    val flow = MutableStateFlow(Signal.initial())
+    // The event bus used to be a conflating MutableStateFlow: while a collector (e.g. the trigger
+    // runner) was busy handling one signal, any further distinct signals emitted in the same tick
+    // were dropped, so the collector only ever saw the latest. A buffered SharedFlow keeps each
+    // signal; a slow collector is backpressured (emit suspends once 64 are pending) rather than
+    // having intermediate signals silently discarded. replay = 0 because nobody should receive
+    // signals emitted before they started listening (which is also why getNext no longer drops one).
+    val flow = MutableSharedFlow<Signal>(
+        replay = 0,
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.SUSPEND,
+    )
 
     suspend fun emit(signal: Signal) {
         log.trace("Emit signal: {}", signal)
@@ -22,7 +32,6 @@ class SignalService(app: AppServices) : Service(app) {
 
     suspend fun getNext(signalType: SignalType, onSignal: suspend (Signal) -> Unit) {
         flow
-            .drop(1)
             .filter { it.type == signalType }
             .take(1)
             .collect { onSignal(it) }

--- a/src/test/kotlin/party/jml/SignalBusTest.kt
+++ b/src/test/kotlin/party/jml/SignalBusTest.kt
@@ -1,0 +1,66 @@
+package party.jml
+
+import arrow.core.right
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import party.jml.partyboi.AppServices
+import party.jml.partyboi.signals.Signal
+import party.jml.partyboi.signals.SignalType
+import java.util.Collections
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SignalBusTest : PartyboiTester {
+
+    // Regression: the signal bus was a conflating MutableStateFlow, so while a collector was busy
+    // handling one signal, further distinct signals emitted in the same burst were dropped and only
+    // the latest survived. A buffered SharedFlow must deliver every signal of the burst.
+    @Test
+    fun testSignalBurstIsNotConflated() = test {
+        var appRef: AppServices? = null
+        setupServices {
+            appRef = this
+            Unit.right()
+        }
+
+        it.login() // force application startup
+        val signals = appRef!!.signals
+
+        val n = 10
+        val received = Collections.synchronizedList(mutableListOf<String>())
+        val allReceived = CompletableDeferred<Unit>()
+
+        coroutineScope {
+            // A deliberately slow collector: with the old conflating StateFlow it only ever saw the
+            // latest signal of a burst, dropping the ones emitted while it was busy.
+            val base = signals.flow.subscriptionCount.value
+            val collector = launch {
+                signals.flow
+                    .filter { it.type == SignalType.slideShown }
+                    .collect { signal ->
+                        received.add(signal.target!!)
+                        delay(30)
+                        if (received.size >= n) allReceived.complete(Unit)
+                    }
+            }
+            // Wait until the collector has actually subscribed before emitting the burst.
+            while (signals.flow.subscriptionCount.value <= base) delay(10)
+
+            repeat(n) { i -> signals.emit(Signal.slideShown(UUID(0L, i.toLong()))) }
+
+            withTimeout(5_000) { allReceived.await() }
+            collector.cancel()
+        }
+
+        assertEquals(
+            n,
+            received.toList().distinct().size,
+            "every distinct signal in the burst must be delivered, not conflated to the latest",
+        )
+    }
+}


### PR DESCRIPTION
The internal event bus (`SignalService.flow`) was a conflating `MutableStateFlow`. While any collector — the trigger runner, the automatic vote-key granter, or a long-poll waiter — was busy handling one signal, further **distinct** signals emitted in the same tick were dropped and only the latest survived.

This bites the trigger runner in particular: `EventSignalEmitter` emits one signal per scheduled event in a tight loop, so two events firing in the same one-second tick (e.g. "close submitting for compo A" + "open voting for compo A", scheduled together) could lose one event's triggers — voting/submission silently never opening or closing.

## Fix
Replace the `MutableStateFlow` with a buffered `MutableSharedFlow`:
- `extraBufferCapacity = 64`, `onBufferOverflow = SUSPEND` — every signal is delivered; a slow collector is backpressured instead of silently dropping intermediate signals.
- `replay = 0` — nobody should receive signals emitted before they subscribed. This also lets `getNext` drop its leading `drop(1)`, which only existed to skip the `StateFlow`'s replayed current value.

The change is confined to `SignalService`: the two collectors use plain `.collect {}` (identical on `SharedFlow`), nothing reads `flow.value`, and `getNext`'s `drop(1)` was purely a `StateFlow` artifact.

## Test
`SignalBusTest` emits a burst of distinct signals to a deliberately slow collector and asserts every one is delivered. Verified the **conflating `StateFlow` fails it** (the collector only ever sees the latest, so the test times out).

Independent of #108 (different files); can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)