### PR TITLE
UI consistency, English and brevity pass

### DIFF
--- a/src/main/kotlin/party/jml/partyboi/Config.kt
+++ b/src/main/kotlin/party/jml/partyboi/Config.kt
@@ -13,7 +13,7 @@ object Config {
 
     fun get(app: Application? = null): ConfigReader {
         if (instance == null) {
-            if (app == null) throw RuntimeException("Application tried to use configuration before initialializing the config reader")
+            if (app == null) throw RuntimeException("Application tried to use configuration before initializing the config reader")
             instance = ConfigReader(app.environment.config)
         }
         return instance!!

--- a/src/main/kotlin/party/jml/partyboi/assets/admin/AdminAssetsPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/assets/admin/AdminAssetsPage.kt
@@ -6,6 +6,7 @@ import party.jml.partyboi.form.submitButton
 import party.jml.partyboi.templates.Page
 import party.jml.partyboi.templates.components.columns
 import party.jml.partyboi.templates.components.deleteButton
+import party.jml.partyboi.templates.components.confirmDelete
 
 object AdminAssetsPage {
     fun render(assets: List<Asset>, error: String? = null) =
@@ -35,7 +36,7 @@ object AdminAssetsPage {
                                                 deleteButton(
                                                     url = "/admin/assets-dir/$directory",
                                                     tooltipText = "Delete /$directory",
-                                                    confirmation = "Do you really want to delete /$directory and all ${files.size} files in it?"
+                                                    confirmation = confirmDelete("directory", "/$directory", cascade = "all ${files.size} files in it")
                                                 )
                                             }
                                         }
@@ -63,7 +64,7 @@ object AdminAssetsPage {
                                                             deleteButton(
                                                                 url = "/admin/assets/$asset",
                                                                 tooltipText = "Delete ${asset.truncatedName}",
-                                                                confirmation = "Do you really want to delete file $asset?"
+                                                                confirmation = confirmDelete("file", asset.toString())
                                                             )
                                                         }
                                                     }

--- a/src/main/kotlin/party/jml/partyboi/assets/admin/AdminAssetsPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/assets/admin/AdminAssetsPage.kt
@@ -4,9 +4,10 @@ import kotlinx.html.*
 import party.jml.partyboi.assets.Asset
 import party.jml.partyboi.form.submitButton
 import party.jml.partyboi.templates.Page
+import party.jml.partyboi.templates.components.cardHeader
 import party.jml.partyboi.templates.components.columns
-import party.jml.partyboi.templates.components.deleteButton
 import party.jml.partyboi.templates.components.confirmDelete
+import party.jml.partyboi.templates.components.deleteButton
 
 object AdminAssetsPage {
     fun render(assets: List<Asset>, error: String? = null) =
@@ -93,7 +94,7 @@ object AdminAssetsPage {
             ) {
                 form(action = "/admin/assets", method = FormMethod.post, encType = FormEncType.multipartFormData) {
                     article {
-                        header { +"Add assets" }
+                        cardHeader("Add assets")
                         fieldSet {
                             if (error != null) {
                                 section(classes = "error") { +error }

--- a/src/main/kotlin/party/jml/partyboi/auth/AuthRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/auth/AuthRouting.kt
@@ -72,7 +72,7 @@ fun Application.configureLoginRouting(app: AppServices) {
                     RegistrationPage.render(
                         form.mapError {
                             if (it.message.contains("duplicate key value")) {
-                                Notice("The user name or email has already been registered")
+                                Notice("That username or email is already registered")
                             } else {
                                 it
                             }

--- a/src/main/kotlin/party/jml/partyboi/auth/PasswordResetPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/auth/PasswordResetPage.kt
@@ -12,13 +12,13 @@ object PasswordResetPage {
             url = "/reset-password",
             form = form,
             title = "Reset password",
-            submitButtonLabel = "Request password reset link to email",
+            submitButtonLabel = "Send reset link",
         )
     }
 
     fun emailSent() = Page("Password reset") {
         article {
-            +"Password reset email has been sent to the given email address. Check your mail now."
+            +"A password reset email is on its way. Check your inbox."
         }
     }
 

--- a/src/main/kotlin/party/jml/partyboi/auth/RegistrationPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/auth/RegistrationPage.kt
@@ -2,13 +2,13 @@ package party.jml.partyboi.auth
 
 import kotlinx.html.article
 import kotlinx.html.fieldSet
-import kotlinx.html.header
 import party.jml.partyboi.RecaptchaConfig
 import party.jml.partyboi.form.Form
 import party.jml.partyboi.form.dataForm
 import party.jml.partyboi.form.renderFields
 import party.jml.partyboi.form.submitButton
 import party.jml.partyboi.templates.Page
+import party.jml.partyboi.templates.components.cardHeader
 
 object RegistrationPage {
     fun render(
@@ -19,7 +19,7 @@ object RegistrationPage {
             dataForm("/register") {
                 attributes["id"] = "register"
                 article {
-                    header { +"Register a new account" }
+                    cardHeader("Register a new account")
                     fieldSet { renderFields(formData) }
                     recaptcha
                         ?.let { recaptchaSubmitButton("register", "Register", it) }

--- a/src/main/kotlin/party/jml/partyboi/auth/UserService.kt
+++ b/src/main/kotlin/party/jml/partyboi/auth/UserService.kt
@@ -44,7 +44,7 @@ class UserService(private val app: AppServices) {
         userRepository.updateUser(userId, user)
             .mapLeft {
                 if (it.message.contains("duplicate key value")) {
-                    ValidationError("email", "This email has been registered already", user.email)
+                    ValidationError("email", "That email is already registered", user.email)
                 } else it
             }
             .bind()
@@ -55,7 +55,7 @@ class UserService(private val app: AppServices) {
             if (sendVerificationEmail(updatedUser)?.bind() == true) {
                 app.messages.sendMessage(
                     userId, MessageType.INFO,
-                    "To finish updating your email address, please verify it by following the instructions sent to ${updatedUser.email}"
+                    "To finish updating your email, verify it using the instructions sent to ${updatedUser.email}"
                 )
             }
         }
@@ -92,7 +92,7 @@ class UserService(private val app: AppServices) {
                 if (result.isRight()) {
                     app.messages.sendMessage(
                         assignedUser.id, MessageType.INFO,
-                        "To finish creating your account, please verify your email address by following the instructions sent to ${assignedUser.email}"
+                        "To finish creating your account, verify your email using the instructions sent to ${assignedUser.email}"
                     )
                 } else {
                     app.messages.sendMessage(
@@ -141,7 +141,7 @@ class UserService(private val app: AppServices) {
             app.messages.sendMessage(
                 userId,
                 MessageType.SUCCESS,
-                "Your email has been verified successfully."
+                "Your email has been verified."
             )
             processAutomaticVoteKeyByEmail(userId).bind()
         } else {
@@ -205,7 +205,7 @@ class UserService(private val app: AppServices) {
         val hashedPassword = hashPassword(newPassword)
         userRepository.changePassword(userId, hashedPassword).bind()
         passwordResetRepository.invalidateCode(code).bind()
-        app.messages.sendMessage(userId, MessageType.SUCCESS, "Your password has been changed successfully.").bind()
+        app.messages.sendMessage(userId, MessageType.SUCCESS, "Your password has been changed.").bind()
         userId
     }
 }

--- a/src/main/kotlin/party/jml/partyboi/compos/ResultsPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/ResultsPage.kt
@@ -11,7 +11,7 @@ object ResultsPage {
 
         if (results.isEmpty()) {
             article {
-                +"No results available yet!"
+                +"No results available yet."
             }
         }
 

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/AdminComposPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/AdminComposPage.kt
@@ -109,10 +109,10 @@ object AdminComposPage {
             } else null) {
 
             renderForm(
-                title = "Add new compo",
+                title = "New compo",
                 url = "/admin/compos",
                 form = newCompoForm,
-                submitButtonLabel = "Add",
+                submitButtonLabel = "Add compo",
             )
 
             renderForm(

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
@@ -191,9 +191,7 @@ object AdminEditCompoPage {
                     }
                 }
 
-                buttonGroup {
-                    button(type = ButtonType.submit) { +"Save changes" }
-                }
+                submitButton("Save changes")
             }
         }, {
 

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
@@ -101,12 +101,12 @@ object AdminEditCompoPage {
         columns({
             dataForm("/admin/compos/${compo.id}") {
                 article {
-                    header { +"General" }
+                    cardHeader("General")
                     fieldSet { renderFields(compoForm) }
                 }
 
                 article {
-                    header { +"Visibility & results" }
+                    cardHeader("Visibility & results")
                     p { small { +"How this compo behaves during the party." } }
                     fieldSet {
                         picoSwitch(
@@ -126,7 +126,7 @@ object AdminEditCompoPage {
 
                 if (!isManual) {
                     article {
-                        header { +"Submissions" }
+                        cardHeader("Submissions")
 
                         fieldSet {
                             legend { +"File uploads" }
@@ -160,7 +160,7 @@ object AdminEditCompoPage {
                     }
 
                     article {
-                        header { +"Timing" }
+                        cardHeader("Timing")
                         p { small { +"Feeds the runtime estimate on the Entries tab." } }
                         div(classes = "grid") {
                             label {
@@ -198,7 +198,7 @@ object AdminEditCompoPage {
             // Live state controls live outside the settings form: toggling them PUTs and
             // reloads immediately, independent of the unsaved form fields above.
             article {
-                header { +"State" }
+                cardHeader("State")
                 table {
                     tbody {
                         tr {
@@ -484,7 +484,7 @@ object AdminEditCompoPage {
         if (manualResults.isNotEmpty()) {
             val hasTitles = manualResults.any { it.title.isNotBlank() }
             article {
-                header { +"Results" }
+                cardHeader("Results")
                 table {
                     thead {
                         tr {
@@ -532,7 +532,7 @@ object AdminEditCompoPage {
 
         article {
             if (editResultId != null) {
-                header { +"Edit result" }
+                cardHeader("Edit result")
                 dataForm("/admin/compos/${compo.id}/manual-results/$editResultId") {
                     fieldSet {
                         renderFields(form)

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
@@ -548,7 +548,7 @@ object AdminEditCompoPage {
                     }
                 }
             } else {
-                header { +"Add result" }
+                cardHeader("New result")
                 dataForm("/admin/compos/${compo.id}/manual-results") {
                     fieldSet {
                         renderFields(form)

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
@@ -384,7 +384,7 @@ object AdminEditCompoPage {
                 deleteButton(
                     url = "/admin/compos/entries/${entry.id}",
                     tooltipText = "Delete entry",
-                    confirmation = "Delete entry \"${entry.title}\"? This cannot be undone.",
+                    confirmation = confirmDelete("entry", entry.title),
                 )
             }
         }
@@ -518,7 +518,7 @@ object AdminEditCompoPage {
                                     deleteButton(
                                         "/admin/compos/${compo.id}/manual-results/${result.id}",
                                         tooltipText = "Delete result",
-                                        confirmation = "Delete this result?"
+                                        confirmation = confirmDelete("result", result.author)
                                     )
                                 }
                             }

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/AdminEditCompoPage.kt
@@ -325,7 +325,7 @@ object AdminEditCompoPage {
                     }
                 }
                 small {
-                    icon("arrows-up-down")
+                    icon("grip-vertical")
                     +" Drag to set run order · durations auto-detected from uploaded media"
                 }
             }
@@ -505,7 +505,7 @@ object AdminEditCompoPage {
                         manualResults.forEachIndexed { index, result ->
                             tr {
                                 attributes.put("data-dragid", result.id.toString())
-                                td(classes = "handle") { icon("arrows-up-down") }
+                                td(classes = "handle") { icon("grip-vertical") }
                                 td(classes = "place-number") { +"${index + 1}." }
                                 td {
                                     a(href = "/admin/compos/${compo.id}/manual-results/${result.id}") {
@@ -527,7 +527,7 @@ object AdminEditCompoPage {
                 }
                 small {
                     +"Set order by dragging results by "
-                    icon("arrows-up-down")
+                    icon("grip-vertical")
                 }
             }
         }

--- a/src/main/kotlin/party/jml/partyboi/compos/admin/CompoRunService.kt
+++ b/src/main/kotlin/party/jml/partyboi/compos/admin/CompoRunService.kt
@@ -208,7 +208,7 @@ class CompoRunService(app: AppServices) : Service(app) {
         app.files.getLatest(entry.id, originalsOnly = false)
             .mapLeft {
                 when (it) {
-                    is NotFound -> NotFound("Entry '${entry.author} - ${entry.title}' does not have file. Disqualify it first.")
+                    is NotFound -> NotFound("Entry '${entry.author} - ${entry.title}' has no file. Disqualify it first.")
                     else -> it
                 }
             }

--- a/src/main/kotlin/party/jml/partyboi/email/EmailTemplates.kt
+++ b/src/main/kotlin/party/jml/partyboi/email/EmailTemplates.kt
@@ -10,16 +10,16 @@ object EmailTemplates {
     fun emailVerification(recipient: User, verificationCode: String, instanceName: String, hostName: String) =
         EmailMessage.build(
             recipient = requireNotNull(recipient.email) { "Cannot send verification email to user without email address" },
-            subject = "Verify your email address to $instanceName",
+            subject = "Verify your $instanceName email address",
         ) {
             p { +"Hi, ${recipient.name}!" }
-            p { +"Thank you for signing up to $instanceName! Please verify your email address by clicking the link below:" }
+            p { +"Thanks for signing up to $instanceName! Verify your email address with the link below:" }
             p {
                 a(href = "$hostName/verify/${recipient.id}/$verificationCode") {
                     +"\uD83D\uDC49 Verify email"
                 }
             }
-            p { +"If you didn’t request this, you can safely ignore this message." }
+            p { +"If you didn't request this, you can safely ignore this message." }
             signature(instanceName)
         }
 
@@ -29,13 +29,13 @@ object EmailTemplates {
             subject = "Reset your $instanceName password",
         ) {
             p { +"Hi!" }
-            p { +"We received a request to reset your password. You can create a new one by clicking the link below:" }
+            p { +"We got a request to reset your password. Create a new one with the link below:" }
             p {
                 a(href = "$hostName/reset-password/$resetCode") {
                     +"\uD83D\uDC49 Reset password"
                 }
             }
-            p { +"This link will expire in 30 minutes. If you didn't request a password reset, you can safely ignore this email." }
+            p { +"This link expires in 30 minutes. If you didn't request this, you can safely ignore this email." }
             signature(instanceName)
         }
 

--- a/src/main/kotlin/party/jml/partyboi/entries/EditEntryPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EditEntryPage.kt
@@ -9,6 +9,7 @@ import party.jml.partyboi.form.Form
 import party.jml.partyboi.form.renderForm
 import party.jml.partyboi.system.displayDateTime
 import party.jml.partyboi.templates.Page
+import party.jml.partyboi.templates.components.cardHeader
 import party.jml.partyboi.templates.components.columns
 import party.jml.partyboi.templates.components.icon
 
@@ -73,7 +74,7 @@ object EditEntryPage {
 
             if (files.isNotEmpty()) {
                 article(classes = "fileversions") {
-                    header { +"File versions" }
+                    cardHeader("File versions")
                     table {
                         thead {
                             tr {

--- a/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
@@ -38,7 +38,7 @@ fun FlowContent.entryList(
     previews: List<Preview>,
 ) {
     if (userEntries.isNotEmpty()) {
-        h1 { +"My entries" }
+        h2 { +"My entries" }
 
         userEntries.forEach { entry ->
             entryCard(entry, previews.find { it.entryId == entry.id }, compos) {

--- a/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
@@ -14,7 +14,7 @@ object EntriesPage {
         compos: List<Compo>,
         userEntries: List<EntryWithLatestFile>,
         previews: List<Preview>,
-    ) = Page("Submit entries") {
+    ) = Page("Entries") {
         h1 { +"Entries" }
 
         if (compos.isEmpty() && userEntries.isEmpty()) {

--- a/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
@@ -5,12 +5,8 @@ import party.jml.partyboi.compos.Compo
 import party.jml.partyboi.form.Form
 import party.jml.partyboi.form.renderForm
 import party.jml.partyboi.form.renderReadonlyFields
-import party.jml.partyboi.templates.Javascript
 import party.jml.partyboi.templates.Page
-import party.jml.partyboi.templates.components.buttonGroup
-import party.jml.partyboi.templates.components.columns
-import party.jml.partyboi.templates.components.entryCard
-import party.jml.partyboi.templates.components.icon
+import party.jml.partyboi.templates.components.*
 
 object EntriesPage {
     fun render(
@@ -63,18 +59,11 @@ fun FlowContent.entryList(
                     }
 
                     if (compo?.allowSubmit == true) {
-                        a {
-                            href = "#"
-                            role = "button"
-                            onClick = Javascript.build {
-                                confirm("Do you really want to delete entry \"${entry.title}\" by ${entry.author}?") {
-                                    httpDelete("/entries/${entry.id}")
-                                    refresh()
-                                }
-                            }
-                            icon("trash")
-                            +" Delete"
-                        }
+                        deleteButton(
+                            url = "/entries/${entry.id}",
+                            tooltipText = "Delete entry",
+                            confirmation = confirmDelete("entry", entry.title),
+                        )
                     }
                 }
             }

--- a/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/entries/EntriesPage.kt
@@ -18,7 +18,7 @@ object EntriesPage {
         h1 { +"Entries" }
 
         if (compos.isEmpty() && userEntries.isEmpty()) {
-            article { +"Submitting entries disabled. \uD83D\uDE25" }
+            article { +"Submitting entries is disabled." }
         }
 
         columns(
@@ -73,7 +73,7 @@ fun FlowContent.entryList(
 
 fun FlowContent.submitNewEntryForm(url: String, openCompos: List<Compo>, values: Form<NewEntry>) {
     if (openCompos.isEmpty()) {
-        article { +"Submitting is closed" }
+        article { +"Submitting is closed." }
     } else {
         renderForm(
             title = "Submit a new entry",

--- a/src/main/kotlin/party/jml/partyboi/form/FormComponents.kt
+++ b/src/main/kotlin/party/jml/partyboi/form/FormComponents.kt
@@ -6,6 +6,7 @@ import party.jml.partyboi.assets.Asset
 import party.jml.partyboi.data.UserError
 import party.jml.partyboi.data.randomShortId
 import party.jml.partyboi.templates.Javascript
+import party.jml.partyboi.templates.components.cardHeader
 import party.jml.partyboi.templates.components.tooltip
 import party.jml.partyboi.validation.Validateable
 import kotlin.enums.enumEntries
@@ -253,7 +254,7 @@ fun <T : Validateable<T>> FlowContent.renderForm(
 ) {
     dataForm(url, ajax) {
         article {
-            if (title != null) header { +title }
+            if (title != null) cardHeader(title)
             fieldSet { renderFields(form, options) }
             submitButton(submitButtonLabel)
         }

--- a/src/main/kotlin/party/jml/partyboi/frontpage/FrontPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/frontpage/FrontPage.kt
@@ -62,7 +62,7 @@ object FrontPage {
                         }
                     }
                 } else {
-                    article { +"Nothing to share yet..." }
+                    article { +"Nothing to share yet." }
                 }
             },
             {
@@ -70,7 +70,7 @@ object FrontPage {
                 if (events.isNotEmpty()) {
                     schedule(events)
                 } else {
-                    article { +"Schedule will be released soon!" }
+                    article { +"Schedule will be released soon." }
                 }
             }
 

--- a/src/main/kotlin/party/jml/partyboi/frontpage/FrontPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/frontpage/FrontPage.kt
@@ -2,8 +2,10 @@ package party.jml.partyboi.frontpage
 
 import kotlinx.html.a
 import kotlinx.html.article
+import kotlinx.html.h1
 import kotlinx.html.h2
 import kotlinx.html.p
+import party.jml.partyboi.Config
 import party.jml.partyboi.infoscreen.SlideRow
 import party.jml.partyboi.infoscreen.slides.QrCodeSlide
 import party.jml.partyboi.infoscreen.slides.TextSlide
@@ -18,6 +20,8 @@ import party.jml.partyboi.voting.LiveVoteState
 
 object FrontPage {
     fun render(events: List<Event>, infoScreen: List<SlideRow>, liveVote: LiveVoteState?) = Page("Home") {
+        h1(classes = "visually-hidden") { +Config.get().instanceName }
+
         if (liveVote?.open == true) {
             buttonGroup {
                 a(href = "/vote") {

--- a/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
@@ -59,7 +59,7 @@ object AdminScreenPage {
                 if (slideSet != SlideSetRow.ADHOC && slideSet != SlideSetRow.DEFAULT) {
                     deleteButton(
                         url = "/admin/screen/slideset/$slideSet",
-                        confirmation = "Delete the \"$slideSetName\" slideset and all its slides?",
+                        confirmation = confirmDelete("slide set", slideSetName, cascade = "all its slides"),
                         label = "Delete",
                         redirectUrl = "/admin/screen",
                         classes = "primary",
@@ -196,7 +196,7 @@ object AdminScreenPage {
                                             deleteButton(
                                                 url = "/admin/screen/${slide.id}",
                                                 tooltipText = "Delete ${slide.getName()}",
-                                                confirmation = "Do you really want to delete slide ${slide.getName()}?"
+                                                confirmation = confirmDelete("slide", slide.getName())
                                             )
                                         }
                                     }

--- a/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
@@ -111,19 +111,19 @@ object AdminScreenPage {
                                     li {
                                         a(href = "/admin/screen/${slideSet}/new/textslide", classes = "flat-button") {
                                             icon(Icon("list-ul"))
-                                            +" Normal text slide"
+                                            +" Text slide"
                                         }
                                     }
                                     li {
                                         a(href = "/admin/screen/${slideSet}/new/qrcodeslide", classes = "flat-button") {
                                             icon(Icon("qrcode"))
-                                            +" Slide with a QR code"
+                                            +" QR code slide"
                                         }
                                     }
                                     li {
                                         a(href = "/admin/screen/${slideSet}/new/imageslide", classes = "flat-button") {
                                             icon(Icon("image"))
-                                            +" Full screen images"
+                                            +" Image slides"
                                         }
                                     }
                                 }

--- a/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
@@ -54,7 +54,7 @@ object AdminScreenPage {
                 a(href = "/admin/screen/new") {
                     attributes["role"] = "button"
                     icon("plus")
-                    +" New slideset"
+                    +" New slide set"
                 }
                 if (slideSet != SlideSetRow.ADHOC && slideSet != SlideSetRow.DEFAULT) {
                     deleteButton(
@@ -77,7 +77,7 @@ object AdminScreenPage {
                                 li {
                                     val isDisabled = slides.all { !it.visible }
                                     if (isDisabled) {
-                                        tooltip("Need at least one slide set visible to activate autorun")
+                                        tooltip("Need at least one slide set visible to activate auto run")
                                     }
                                     postButton("/admin/screen/${slideSet}/start") {
                                         disabled = isDisabled
@@ -293,14 +293,14 @@ object AdminScreenPage {
         form: Form<NewSlideSet>,
         slideSets: List<SlideSetRow>,
     ) = Page(
-        title = "New slideset",
+        title = "New slide set",
         subLinks = generateSubLinks(slideSets),
     ) {
-        h1 { +"New slideset" }
+        h1 { +"New slide set" }
         renderForm(
             url = "/admin/screen/new",
             form = form,
-            submitButtonLabel = "Create slideset",
+            submitButtonLabel = "Create slide set",
         )
     }
 

--- a/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
@@ -324,7 +324,7 @@ object AdminScreenPage {
             encType = FormEncType.multipartFormData,
         ) {
             article {
-                header { +"Upload images" }
+                cardHeader("Upload images")
                 fieldSet {
                     if (uploadError != null) {
                         section(classes = "error") { +uploadError }
@@ -345,7 +345,7 @@ object AdminScreenPage {
             method = FormMethod.post,
         ) {
             article {
-                header { +"Pick images to add as slides" }
+                cardHeader("Pick images to add as slides")
                 if (availableImages.isEmpty()) {
                     p { +"No unused images — upload some above." }
                 } else {
@@ -410,7 +410,7 @@ object AdminScreenPage {
 
         if (triggers.isNotEmpty()) {
             article {
-                header { +"When this slide is shown the following actions are executed automatically" }
+                cardHeader("When this slide is shown the following actions are executed automatically")
                 ul { triggers.forEach { li { +it.description } } }
             }
         }

--- a/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/infoscreen/admin/AdminScreenPage.kt
@@ -142,7 +142,7 @@ object AdminScreenPage {
                                 tr {
                                     attributes.put("data-dragid", slide.id.toString())
                                     if (!slide.readOnly) {
-                                        td(classes = "handle tight") { icon("arrows-up-down") }
+                                        td(classes = "handle tight") { icon("grip-vertical") }
                                     } else {
                                         td(classes = "tight") {}
                                     }

--- a/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
+++ b/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
@@ -41,7 +41,7 @@ object AdminSchedulePage {
                         .groupBy { it.startTime.toDate() }
                         .forEach { (date, events) ->
                             article {
-                                header { +date.displayDate() }
+                                cardHeader(date.displayDate())
                                 table(classes = "schedule") {
                                     thead {
                                         tr {
@@ -154,7 +154,7 @@ object AdminSchedulePage {
             }, {
                 if (triggers.isNotEmpty()) {
                     article {
-                        header { +"Triggers" }
+                        cardHeader("Triggers")
                         p { +"These actions will happen at the scheduled start time of the event" }
                         table {
                             thead {

--- a/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
+++ b/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
@@ -131,7 +131,7 @@ object AdminSchedulePage {
                 deleteButton(
                     url = "/admin/schedule/events/$id",
                     tooltipText = "Delete event",
-                    confirmation = "Are you sure you want to delete event '${event.name}'?"
+                    confirmation = confirmDelete("event", event.name)
                 )
             }
         }

--- a/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
+++ b/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
@@ -190,7 +190,7 @@ object AdminSchedulePage {
                 }
 
                 renderForm(
-                    title = "Add new trigger",
+                    title = "New trigger",
                     url = "/admin/schedule/triggers",
                     form = newTriggerForm,
                     options = mapOf(

--- a/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
+++ b/src/main/kotlin/party/jml/partyboi/schedule/admin/AdminSchedulePage.kt
@@ -58,7 +58,7 @@ object AdminSchedulePage {
                         }
                 }
                 renderForm(
-                    title = "New Event",
+                    title = "New event",
                     url = "/admin/schedule/events",
                     form = newEventForm,
                     submitButtonLabel = "Add event",

--- a/src/main/kotlin/party/jml/partyboi/settings/SettingsService.kt
+++ b/src/main/kotlin/party/jml/partyboi/settings/SettingsService.kt
@@ -55,7 +55,7 @@ class SettingsService(app: AppServices) : Service(app) {
             raise(
                 ValidationError(
                     "automaticVoteKeys",
-                    "This option cannot be selected because email service has not been configured",
+                    "Requires a configured email service",
                     ""
                 )
             )

--- a/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
@@ -8,6 +8,7 @@ import party.jml.partyboi.system.TimeService
 import party.jml.partyboi.templates.Page
 import party.jml.partyboi.templates.components.buttonGroup
 import party.jml.partyboi.templates.components.buttonLink
+import party.jml.partyboi.templates.components.cardHeader
 import party.jml.partyboi.templates.components.timestamp
 import java.net.URI
 
@@ -38,7 +39,7 @@ object SyncPage {
 
             if (canSync) {
                 article {
-                    header { +"Sync now" }
+                    cardHeader("Sync now")
                     p {
                         +"Run a sync against the configured remote instance below. Both actions transfer "
                         +"every syncable table (users, compos, entries, votes, schedule, …) and any "
@@ -76,7 +77,7 @@ object SyncPage {
             }
 
             article {
-                header { +"Remote instance configuration" }
+                cardHeader("Remote instance configuration")
                 p {
                     +"Point this instance at another Partyboi server you want to sync with. Fill in "
                     +"that server's public address and the token its admin generated under "
@@ -92,7 +93,7 @@ object SyncPage {
             }
 
             article {
-                header { +"Data master" }
+                cardHeader("Data master")
                 p {
                     +"Controls whether "
                     em { +"other" }
@@ -132,7 +133,7 @@ object SyncPage {
             if (syncLog.isNotEmpty()) {
                 val tz = TimeService.timeZone()
                 article {
-                    header { +"Log" }
+                    cardHeader("Log")
                     p {
                         small {
                             +"Recent sync attempts on this instance, in start order. Each table transfer "

--- a/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
@@ -188,8 +188,8 @@ object SyncPage {
         }
 
     fun renderNewToken(host: URI, token: String) =
-        Page("New API Token") {
-            h1 { +"New API Token created" }
+        Page("New API token") {
+            h1 { +"New API token created" }
 
             article {
                 p {

--- a/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
@@ -18,22 +18,16 @@ object SyncPage {
             h1 { +"Remote sync" }
 
             p {
-                +"Sync copies data and uploaded files between two Partyboi instances over HTTP. "
-                +"A typical setup has a pre-party instance that collects registrations and entries online, "
-                +"and an on-site instance at the party that runs the compos. Before the party you pull the "
-                +"pre-party data onto the on-site instance; after the party you push results back."
+                +"Sync copies data and files between two Partyboi instances over HTTP — pull "
+                +"entries from a pre-party instance before the event, push results back after."
             }
             p {
                 small {
-                    +"Each instance plays one or two roles. The "
+                    +"Each instance has a role. A "
                     strong { +"data master" }
-                    +" is the instance other instances read from — it must enable syncing and hand out a "
-                    +"token. A "
+                    +" enables syncing and hands out a token; a "
                     strong { +"client" }
-                    +" is an instance that has been told the master's address and token and can pull from "
-                    +"or push to it. The same server can do both — generate a token for inbound sync "
-                    em { +"and" }
-                    +" point at another server for outbound sync."
+                    +" uses a master's address and token to pull from or push to it. One server can be both."
                 }
             }
 
@@ -41,32 +35,23 @@ object SyncPage {
                 article {
                     cardHeader("Sync now")
                     p {
-                        +"Run a sync against the configured remote instance below. Both actions transfer "
-                        +"every syncable table (users, compos, entries, votes, schedule, …) and any "
-                        +"missing uploaded files. They run in the background — watch the log at the "
-                        +"bottom of the page for progress."
+                        +"Both actions transfer every syncable table and any missing files, and run "
+                        +"in the background — watch the log below."
                     }
                     ul {
                         li {
                             strong { +"Download" }
-                            +" — pull data and files "
-                            em { +"from" }
-                            +" the remote into this instance. Use this on the on-site instance before "
-                            +"the party to bring in everything the pre-party instance has collected. "
-                            +"Existing rows with the same primary key are overwritten."
+                            +" — pull from the remote into this instance (e.g. before the party)."
                         }
                         li {
                             strong { +"Upload" }
-                            +" — push data and files "
-                            em { +"from" }
-                            +" this instance to the remote. Use this after the party to send results, "
-                            +"votes and any entries added on-site back to the pre-party instance."
+                            +" — push from this instance to the remote (e.g. after the party)."
                         }
                     }
                     p {
                         small {
-                            +"Both directions overwrite the target's rows where IDs collide, so only run "
-                            +"the direction that matches which instance currently holds the truth."
+                            +"Both directions overwrite the target's rows where IDs collide, so run only "
+                            +"the direction whose source holds the current data."
                         }
                     }
                     buttonGroup {
@@ -79,12 +64,12 @@ object SyncPage {
             article {
                 cardHeader("Remote instance configuration")
                 p {
-                    +"Point this instance at another Partyboi server you want to sync with. Fill in "
-                    +"that server's public address and the token its admin generated under "
+                    +"Point this instance at another Partyboi server: enter its public address and a "
+                    +"token it generated under "
                     em { +"Data master" }
-                    +" on its own sync page. Without this, the "
+                    +". Without this, the "
                     em { +"Sync now" }
-                    +" actions above are hidden."
+                    +" actions are hidden."
                 }
                 renderForm(
                     url = "/sync/remote",
@@ -95,17 +80,16 @@ object SyncPage {
             article {
                 cardHeader("Data master")
                 p {
-                    +"Controls whether "
+                    +"Lets "
                     em { +"other" }
-                    +" Partyboi instances are allowed to sync with this one. Generating a token turns "
-                    +"this instance into a data master: anyone who knows this server's address and the "
-                    +"token can read and write its data through the sync API."
+                    +" instances sync with this one. Anyone with this server's address and the token "
+                    +"can read and write its data over the sync API."
                 }
 
                 if (apiKey == null) {
                     p {
                         strong { +"Status: " }
-                        +"syncing is disabled. No other instance can pull data from this server."
+                        +"syncing is disabled. No other instance can reach this server."
                     }
                     form("/sync/new-token", method = FormMethod.post) {
                         submitButton("Enable syncing and generate a token")
@@ -113,15 +97,15 @@ object SyncPage {
                 } else {
                     p {
                         strong { +"Status: " }
-                        +"this instance is waiting for sync requests. The previously issued token is "
-                        +"still valid; generating a new one immediately invalidates the old one."
+                        +"waiting for sync requests. The current token stays valid; generating a new "
+                        +"one invalidates it."
                     }
                     p {
                         small {
-                            +"The token is shown only once — right after it is created. Copy it into "
-                            +"the other instance's "
+                            +"The token is shown only once, right after creation — copy it into the "
+                            +"other instance's "
                             em { +"Remote instance configuration" }
-                            +" straight away."
+                            +" immediately."
                         }
                     }
                     form("/sync/new-token", method = FormMethod.post) {
@@ -136,9 +120,8 @@ object SyncPage {
                     cardHeader("Log")
                     p {
                         small {
-                            +"Recent sync attempts on this instance, in start order. Each table transfer "
-                            +"and file transfer gets its own row, so a single Download or Upload run "
-                            +"produces many entries."
+                            +"Recent sync attempts in start order. Each table and file transfer is its "
+                            +"own row, so one run produces many."
                         }
                     }
                     table {
@@ -194,18 +177,16 @@ object SyncPage {
 
             article {
                 p {
-                    +"Copy these two values into the "
+                    +"Copy these values into the "
                     em { +"Remote instance configuration" }
                     +" form on the "
                     strong { +"other" }
-                    +" Partyboi instance — the one that should sync with this server. That instance "
-                    +"will then be able to download data from, or upload data to, this server."
+                    +" Partyboi instance — the one that should sync with this server."
                 }
                 p {
                     small {
                         strong { +"This token is shown only once." }
-                        +" There is no way to recover it later — if you lose it, generate a new one "
-                        +"(which invalidates this one)."
+                        +" If you lose it, generate a new one (which invalidates this one)."
                     }
                 }
                 table {

--- a/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/sync/SyncPage.kt
@@ -219,7 +219,7 @@ object SyncPage {
                         }
                     }
                 }
-                a(href = "/sync") { +"Get back" }
+                a(href = "/sync") { +"Back to sync" }
             }
         }
 }

--- a/src/main/kotlin/party/jml/partyboi/system/admin/AdminErrorLogPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/system/admin/AdminErrorLogPage.kt
@@ -39,7 +39,7 @@ object AdminErrorLogPage {
     }
 
     fun renderStackTrace(error: ErrorRow): Page = Page("Error ${error.key}") {
-        h1 { +"Stack trace" }
+        h1 { +"Error ${error.key}" }
 
         table(classes = "compact striped") {
             tbody {

--- a/src/main/kotlin/party/jml/partyboi/system/admin/AdminErrorLogPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/system/admin/AdminErrorLogPage.kt
@@ -1,14 +1,16 @@
 package party.jml.partyboi.system.admin
 
+import kotlinx.datetime.TimeZone
 import kotlinx.html.*
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import party.jml.partyboi.system.ErrorRow
+import party.jml.partyboi.system.displayDateTime
 import party.jml.partyboi.templates.Page
 
 object AdminErrorLogPage {
-    fun renderList(errors: List<ErrorRow>): Page = Page("Error log") {
+    fun renderList(errors: List<ErrorRow>, tz: TimeZone): Page = Page("Error log") {
         h1 { +"Error log" }
         article {
             table(classes = "compact striped") {
@@ -24,7 +26,7 @@ object AdminErrorLogPage {
                     errors.forEach { error ->
                         tr {
                             td { +error.key }
-                            td { +error.time.toString() }
+                            td { +error.time.displayDateTime(tz) }
                             td { +error.message }
                             td {
                                 a(href = "/admin/errors/${error.id}") {

--- a/src/main/kotlin/party/jml/partyboi/system/admin/AdminErrorLogRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/system/admin/AdminErrorLogRouting.kt
@@ -12,7 +12,8 @@ fun Application.configureAdminErrorLogRouting(app: AppServices) {
         get("/admin/errors") {
             call.respondEither {
                 val errors = app.errors.getErrors(100, 0).bind()
-                AdminErrorLogPage.renderList(errors)
+                val tz = app.time.timeZone.get().bind()
+                AdminErrorLogPage.renderList(errors, tz)
             }
         }
 

--- a/src/main/kotlin/party/jml/partyboi/templates/Navigation.kt
+++ b/src/main/kotlin/party/jml/partyboi/templates/Navigation.kt
@@ -50,7 +50,7 @@ object Navigation {
 
     val accountItems = listOf(
         NavItem("/profile", "Profile"),
-        NavItem("/logout", "Log out")
+        NavItem("/logout", "Logout")
     )
 }
 

--- a/src/main/kotlin/party/jml/partyboi/templates/components/DeleteButton.kt
+++ b/src/main/kotlin/party/jml/partyboi/templates/components/DeleteButton.kt
@@ -24,3 +24,15 @@ fun FlowContent.deleteButton(
         if (label != null) +" $label"
     }
 }
+
+/**
+ * Standard confirmation prompt for destructive delete actions, e.g.
+ * `Delete event "Summer Compo"?`. Pass [cascade] for actions that also remove
+ * children, e.g. `confirmDelete("slideset", name, cascade = "all its slides")`
+ * → `Delete slideset "Foo" and all its slides?`.
+ */
+fun confirmDelete(thing: String, name: String? = null, cascade: String? = null): String {
+    val subject = if (name != null) "$thing \"$name\"" else thing
+    val tail = if (cascade != null) " and $cascade" else ""
+    return "Delete $subject$tail?"
+}

--- a/src/main/kotlin/party/jml/partyboi/users/UserEditPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/users/UserEditPage.kt
@@ -31,7 +31,7 @@ object UserEditPage {
                 },
                 {
                     article {
-                        header { +"Vote keys" }
+                        cardHeader("Vote keys")
                         if (voteKeys.isEmpty()) {
                             p { +"User does not have any vote keys" }
                         } else {
@@ -56,7 +56,7 @@ object UserEditPage {
                     }
                     if (showAdminControls) {
                         article {
-                            header { +"Permissions" }
+                            cardHeader("Permissions")
                             buttonGroup {
                                 labeledToggleButton(
                                     toggled = user.isAdmin,

--- a/src/main/kotlin/party/jml/partyboi/users/UserEditPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/users/UserEditPage.kt
@@ -33,9 +33,9 @@ object UserEditPage {
                     article {
                         cardHeader("Vote keys")
                         if (voteKeys.isEmpty()) {
-                            p { +"User does not have any vote keys" }
+                            p { +"No vote keys." }
                         } else {
-                            p { +"Vote key(s) acquired by:" }
+                            p { +"Acquired by:" }
                             ul {
                                 voteKeys.forEach { key ->
                                     li { +key.explain() }
@@ -72,23 +72,18 @@ object UserEditPage {
                         cardHeader("Verification")
                         section {
                             if (user.email == null) {
-                                +"User does not have an email address"
+                                +"No email address."
                             } else {
-                                if (user.emailVerified) {
-                                    +"User has a verified email address "
+                                p {
+                                    +"Email: "
                                     a(href = "mailto:${user.email}") { +user.email }
-                                } else {
+                                    +(if (user.emailVerified) " (verified)" else " (not verified)")
+                                }
+                                if (!user.emailVerified && showAdminControls) {
                                     p {
-                                        +"User has an email address "
-                                        a(href = "mailto:${user.email}") { +user.email }
-                                        +" but it is not verified"
-                                    }
-                                    if (showAdminControls) {
-                                        p {
-                                            a(href = "/admin/users/${user.id}/send-verification") {
-                                                attributes.put("role", "button")
-                                                +"Send verification email"
-                                            }
+                                        a(href = "/admin/users/${user.id}/send-verification") {
+                                            attributes.put("role", "button")
+                                            +"Send verification email"
                                         }
                                     }
                                 }

--- a/src/main/kotlin/party/jml/partyboi/users/UserListPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/users/UserListPage.kt
@@ -10,8 +10,8 @@ object UserListPage {
     fun render(users: List<User>, jmlCaptchaScores: Map<UUID, Double>) = Page(
         title = "Users"
     ) {
+        h1 { +"Users" }
         article {
-            header { +"Users" }
             table {
                 thead {
                     tr {

--- a/src/main/kotlin/party/jml/partyboi/voting/RegisterVoteKeyPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/RegisterVoteKeyPage.kt
@@ -9,9 +9,9 @@ import party.jml.partyboi.validation.MinLength
 import party.jml.partyboi.validation.Validateable
 
 object RegisterVoteKeyPage {
-    fun render(form: Form<VoteKeyForm>) = Page("Enable voting") {
+    fun render(form: Form<VoteKeyForm>) = Page("Register vote key") {
         renderForm(
-            title = "Enable voting",
+            title = "Register vote key",
             url = "/vote/register",
             form = form,
             submitButtonLabel = "Register your vote key"

--- a/src/main/kotlin/party/jml/partyboi/voting/UserVotingPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/UserVotingPage.kt
@@ -117,16 +117,16 @@ object UserVotingPage {
                 section {
                     ul {
                         li {
-                            +"Rate each entry from ${VoteService.MIN_POINTS} (worst) to ${VoteService.MAX_POINTS} (best). Click a number — your vote is saved immediately."
+                            +"Rate each entry from ${VoteService.MIN_POINTS} (worst) to ${VoteService.MAX_POINTS} (best). Click a number to save your vote instantly."
                         }
                         li {
-                            +"You can change your vote at any time while the compo is open for voting."
+                            +"Change your vote any time while voting is open."
                         }
                         li {
-                            +"Once you have voted at least one entry in a compo, every other entry in that compo automatically receives ${VoteService.MEAN_POINTS} points from you. Skipping an entry is not the same as voting against it."
+                            +"Once you vote on any entry in a compo, every other entry there gets ${VoteService.MEAN_POINTS} points from you. Skipping an entry isn't the same as voting against it."
                         }
                         li {
-                            +"If you do not vote any entry in a compo, you contribute no points there."
+                            +"Vote on nothing in a compo and you give it no points."
                         }
                     }
                 }

--- a/src/main/kotlin/party/jml/partyboi/voting/UserVotingPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/UserVotingPage.kt
@@ -29,7 +29,7 @@ object UserVotingPage {
 
             liveVote?.let { live ->
                 if (live.entries.isEmpty()) {
-                    article { +"Live voting for ${live.compo.displayName} begins soon!" }
+                    article { +"Live voting for ${live.compo.displayName} begins soon." }
                 }
             }
 

--- a/src/main/kotlin/party/jml/partyboi/voting/VoteService.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/VoteService.kt
@@ -54,7 +54,7 @@ class VoteService(app: AppServices) : Service(app) {
                 if (isVotingOpen(entry).bind()) {
                     repository.castVote(user.id, entryId, validPoints).bind()
                 } else {
-                    raise(InvalidInput("This entry cannot be voted"))
+                    raise(InvalidInput("This entry can't be voted on"))
                 }
             }
         } else {

--- a/src/main/kotlin/party/jml/partyboi/voting/VotingRouting.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/VotingRouting.kt
@@ -40,7 +40,7 @@ fun Application.configureVotingRouting(app: AppServices) {
             call.processForm<VoteKeyForm>(
                 { data ->
                     val user = call.userSession(app).bind()
-                    if (user.votingEnabled) raise(Unauthorized("You cannot register a vote key because you have voting rights already enabled."))
+                    if (user.votingEnabled) raise(Unauthorized("You already have voting rights."))
 
                     app.voteKeys
                         .registerTicket(user.id, data.code)

--- a/src/main/kotlin/party/jml/partyboi/voting/admin/AdminVotingPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/admin/AdminVotingPage.kt
@@ -8,6 +8,7 @@ import party.jml.partyboi.form.renderForm
 import party.jml.partyboi.settings.AutomaticVoteKeys
 import party.jml.partyboi.settings.VoteSettings
 import party.jml.partyboi.templates.Page
+import party.jml.partyboi.templates.components.cardHeader
 import party.jml.partyboi.voting.VoteKeyRow
 
 object AdminVotingPage {
@@ -26,7 +27,7 @@ object AdminVotingPage {
         )
 
         article {
-            header { +"Create new vote keys" }
+            cardHeader("Create new vote keys")
             a("/admin/voting/generate") {
                 role = "button"
                 +"Generate new vote key tickets"
@@ -34,7 +35,7 @@ object AdminVotingPage {
         }
 
         article {
-            header { +"Browse existing vote keys" }
+            cardHeader("Browse existing vote keys")
             voteKeys.groupBy { it.key.keyType.explain(null) }.forEach { (keyType, keys) ->
                 renderVoteKeyTable("$keyType (${keys.size})", keys, users)
             }

--- a/src/main/kotlin/party/jml/partyboi/voting/admin/GenerateVoteKeysPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/voting/admin/GenerateVoteKeysPage.kt
@@ -1,13 +1,13 @@
 package party.jml.partyboi.voting.admin
 
 import kotlinx.html.article
-import kotlinx.html.header
 import kotlinx.html.li
 import kotlinx.html.ul
 import party.jml.partyboi.form.Form
 import party.jml.partyboi.form.Label
 import party.jml.partyboi.form.renderForm
 import party.jml.partyboi.templates.Page
+import party.jml.partyboi.templates.components.cardHeader
 import party.jml.partyboi.validation.Max
 import party.jml.partyboi.validation.Min
 import party.jml.partyboi.validation.Validateable
@@ -25,7 +25,7 @@ object GenerateVoteKeysPage {
 
     fun renderTickets(tickets: List<VoteKeyRow>) = Page("Print vote keys") {
         article(classes = "votekeys") {
-            header { +"Vote keys" }
+            cardHeader("Vote keys")
             ul {
                 tickets.mapNotNull { it.key.id }.forEach {
                     li { +it }

--- a/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
@@ -17,8 +17,7 @@ object WizardPage {
         article {
             cardHeader("Setup wizard — step 1 of 2")
             p {
-                +"Let's get the basics set up. First, pick the time zone the party runs in and the "
-                +"color scheme you'd like to use. You can change all of these later under "
+                +"Pick the time zone the party runs in and a color scheme. You can change these later under "
                 em { +"Admin → Settings" }
                 +"."
             }

--- a/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
@@ -8,13 +8,14 @@ import party.jml.partyboi.form.renderForm
 import party.jml.partyboi.settings.GeneralSettings
 import party.jml.partyboi.templates.ColorScheme
 import party.jml.partyboi.templates.Page
+import party.jml.partyboi.templates.components.cardHeader
 
 object WizardPage {
     fun renderSettingsStep(settings: Form<GeneralSettings>, autofillTimeZone: Boolean) = Page("Setup wizard") {
         h1 { +"Welcome to Partyboi" }
 
         article {
-            header { +"Setup wizard — step 1 of 2" }
+            cardHeader("Setup wizard — step 1 of 2")
             p {
                 +"Let's get the basics set up. First, pick the time zone the party runs in and the "
                 +"color scheme you'd like to use. You can change all of these later under "

--- a/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/wizard/WizardPage.kt
@@ -17,7 +17,7 @@ object WizardPage {
             header { +"Setup wizard — step 1 of 2" }
             p {
                 +"Let's get the basics set up. First, pick the time zone the party runs in and the "
-                +"colour scheme you'd like to use. You can change all of these later under "
+                +"color scheme you'd like to use. You can change all of these later under "
                 em { +"Admin → Settings" }
                 +"."
             }

--- a/src/main/kotlin/party/jml/partyboi/workqueue/admin/AdminTasksPage.kt
+++ b/src/main/kotlin/party/jml/partyboi/workqueue/admin/AdminTasksPage.kt
@@ -44,7 +44,7 @@ object AdminTasksPage {
     }
 
     fun renderDetails(task: TaskRow, tz: TimeZone): Page = Page("Task ${task.id}") {
-        h1 { +"Task" }
+        h1 { +"Task ${task.id}" }
 
         table(classes = "compact striped") {
             tbody {

--- a/src/main/resources/assets/partyboi.css
+++ b/src/main/resources/assets/partyboi.css
@@ -3,6 +3,20 @@
     --pico-spacing: 0.8rem;
 }
 
+/* Content available to screen readers but not shown visually (e.g. a page's
+   top-level heading where the design has no visible title). */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 th {
     font-weight: 100;
 }

--- a/src/test/kotlin/party/jml/AdminUsersTest.kt
+++ b/src/test/kotlin/party/jml/AdminUsersTest.kt
@@ -21,7 +21,7 @@ class AdminUsersTest : PartyboiTester {
         it.login("admin")
         it.get("/admin/users", HttpStatusCode.OK) {
             relaxed = true
-            findFirst("article header") { text.toBe("Users") }
+            findFirst("h1") { text.toBe("Users") }
         }
     }
 }

--- a/src/test/kotlin/party/jml/InfoPageTest.kt
+++ b/src/test/kotlin/party/jml/InfoPageTest.kt
@@ -17,8 +17,8 @@ class InfoPageTest : PartyboiTester {
         setupServices { Unit.right() }
         it.get("/") {
             article {
-                findFirst { text.toBe("Nothing to share yet...") }
-                findSecond { text.toBe("Schedule will be released soon!") }
+                findFirst { text.toBe("Nothing to share yet.") }
+                findSecond { text.toBe("Schedule will be released soon.") }
             }
         }
     }
@@ -36,7 +36,7 @@ class InfoPageTest : PartyboiTester {
         it.get("/") {
             article {
                 findFirst { text.toBe("Hello, world! Nice to be here!") }
-                findSecond { text.toBe("Schedule will be released soon!") }
+                findSecond { text.toBe("Schedule will be released soon.") }
             }
         }
     }
@@ -64,7 +64,7 @@ class InfoPageTest : PartyboiTester {
 
         it.get("/") {
             article {
-                findFirst { text.toBe("Nothing to share yet...") }
+                findFirst { text.toBe("Nothing to share yet.") }
                 findSecond { text.toBe("Tuesday 18.02.2025 20:08 Foodwave") }
             }
         }

--- a/src/test/kotlin/party/jml/LoginTest.kt
+++ b/src/test/kotlin/party/jml/LoginTest.kt
@@ -81,7 +81,7 @@ class LoginTest : PartyboiTester {
                 append("isUpdate", "")
             }
         ) {
-            findFirst(".error") { text.toBe("The user name or email has already been registered") }
+            findFirst(".error") { text.toBe("That username or email is already registered") }
         }
     }
 
@@ -154,7 +154,7 @@ class LoginTest : PartyboiTester {
         val verificationLink = it.getJson<List<EmailMessage>, _>("/test/mock-emails") { emails ->
             emails.last().let {
                 it.recipient.toBe(emailAddr)
-                it.subject.toBe("Verify your email address to Partyboi (test)")
+                it.subject.toBe("Verify your Partyboi (test) email address")
                 // Scrape the verification link
                 htmlDocument(it.content) {
                     findFirst("a") {
@@ -167,7 +167,7 @@ class LoginTest : PartyboiTester {
         // Verificate email
         it.get(verificationLink) {
             findFirst(".snackbars li span") {
-                text.toBe("Your email has been verified successfully.")
+                text.toBe("Your email has been verified.")
             }
             findSecond(".snackbars li span") {
                 text.toBe("You have been granted rights to vote.")

--- a/src/test/kotlin/party/jml/VoteKeyTest.kt
+++ b/src/test/kotlin/party/jml/VoteKeyTest.kt
@@ -33,7 +33,7 @@ class VoteKeyTest : PartyboiTester {
         // Show vote key registartion for logged-in user
         it.login("user")
         it.get("/vote/register") {
-            findFirst("form header") { text.toBe("Enable voting") }
+            findFirst("form header") { text.toBe("Register vote key") }
         }
 
         // Registration with too short key fails

--- a/src/test/kotlin/party/jml/VoteKeyTest.kt
+++ b/src/test/kotlin/party/jml/VoteKeyTest.kt
@@ -58,7 +58,7 @@ class VoteKeyTest : PartyboiTester {
 
         // Registration again fails
         it.post("/vote/register", VoteKeyForm(voteKey.key.id!!)) {
-            findFirst(".error") { text.toBe("You cannot register a vote key because you have voting rights already enabled.") }
+            findFirst(".error") { text.toBe("You already have voting rights.") }
         }
 
         // Registration by another user with the same key again fails

--- a/src/test/kotlin/party/jml/VotingTest.kt
+++ b/src/test/kotlin/party/jml/VotingTest.kt
@@ -94,7 +94,7 @@ class VotingTest : PartyboiTester {
 
         // Live voting is active but no entries can be voted yet
         it.get("/vote") {
-            findFirst("article") { text.toBe("Live voting for Demo compo begins soon!") }
+            findFirst("article") { text.toBe("Live voting for Demo compo begins soon.") }
         }
         it.buttonClickFails("/vote/${entry!!.id}/3")
 


### PR DESCRIPTION
A two-part copy/UI cleanup. No behavior changes — server-side rendered HTML text, structure, and shared helpers only. All 103 tests pass; assertions touching changed text were updated.

## Part 1 — UI consistency (13 commits)

- **Delete confirmations** — new `confirmDelete(thing, name, cascade)` helper; all prompts read `Delete <thing> "<name>"?` instead of three phrasings / two quote styles.
- **Icons** — Entries delete routed through the shared `deleteButton` (trash-can); every sortable table's drag handle + reorder hint uses `grip-vertical`.
- **Titles ↔ headings** — Entries/Task/Error/vote-key pages now align their browser title with the on-page heading.
- **Heading hierarchy** — home page gets a visually-hidden `h1`, "My entries" → `h2`, Users list gets a real `h1`.
- **Sentence case** — "New Event"/"New API Token" → sentence case.
- **Wording/spelling** — "Logout" (matching "Login"); "slide set", "auto run", American "color".
- **Create forms** — "New X" card title + "Add X" button.
- **Error-log timestamps** — formatted with the configured time zone like the Tasks page.
- **Card headers** — all card titles + `renderForm` now use the semantic `cardHeader` (`<h3>`).
- **Empty states** — neutral tone (no `!`/`…`/emoji).

## Part 2 — English & brevity (2 commits)

- **Condensed** the verbose Sync-page operator docs (~halved), the "How voting works" bullets, and the wizard intro.
- **Tightened** status/error/success messages, the signup/verification/password-reset emails, and several labels; fixed an "initialializing" typo and made the verification email consistent with the password-reset one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)